### PR TITLE
 Add sklearn's DecisionTreeRegressor

### DIFF
--- a/hummingbird/ml/operator_converters/decision_tree.py
+++ b/hummingbird/ml/operator_converters/decision_tree.py
@@ -204,10 +204,28 @@ def convert_sklearn_decision_tree_classifier(operator, device, extra_config):
     operator.raw_operator.estimators_ = [operator.raw_operator]
     return convert_sklearn_random_forest_classifier(operator, device, extra_config)
 
+def convert_sklearn_decision_tree_regressor(operator, device, extra_config):
+    """
+    Converter for `sklearn.tree.DecisionTreeRegressor`.
+
+    Args:
+        operator: An operator wrapping a `sklearn.tree.DecisionTreeRegressor` model
+        device: String defining the type of device the converted operator should be run on
+        extra_config: Extra configuration used to select the best conversion strategy
+
+    Returns:
+        A PyTorch model
+    """
+    assert operator is not None
+
+    operator.raw_operator.estimators_ = [operator.raw_operator]
+    return convert_sklearn_random_forest_regressor(operator, device, extra_config)
+
 
 # Register the converters.
 register_converter("SklearnRandomForestClassifier", convert_sklearn_random_forest_classifier)
 register_converter("SklearnRandomForestRegressor", convert_sklearn_random_forest_regressor)
 register_converter("SklearnDecisionTreeClassifier", convert_sklearn_decision_tree_classifier)
+register_converter("SklearnDecisionTreeRegressor", convert_sklearn_decision_tree_regressor)
 register_converter("SklearnExtraTreesClassifier", convert_sklearn_random_forest_classifier)
 register_converter("SklearnExtraTreesRegressor", convert_sklearn_random_forest_regressor)

--- a/hummingbird/ml/operator_converters/decision_tree.py
+++ b/hummingbird/ml/operator_converters/decision_tree.py
@@ -204,6 +204,7 @@ def convert_sklearn_decision_tree_classifier(operator, device, extra_config):
     operator.raw_operator.estimators_ = [operator.raw_operator]
     return convert_sklearn_random_forest_classifier(operator, device, extra_config)
 
+
 def convert_sklearn_decision_tree_regressor(operator, device, extra_config):
     """
     Converter for `sklearn.tree.DecisionTreeRegressor`.

--- a/hummingbird/ml/operator_converters/decision_tree.py
+++ b/hummingbird/ml/operator_converters/decision_tree.py
@@ -224,9 +224,9 @@ def convert_sklearn_decision_tree_regressor(operator, device, extra_config):
 
 
 # Register the converters.
-register_converter("SklearnRandomForestClassifier", convert_sklearn_random_forest_classifier)
-register_converter("SklearnRandomForestRegressor", convert_sklearn_random_forest_regressor)
 register_converter("SklearnDecisionTreeClassifier", convert_sklearn_decision_tree_classifier)
 register_converter("SklearnDecisionTreeRegressor", convert_sklearn_decision_tree_regressor)
 register_converter("SklearnExtraTreesClassifier", convert_sklearn_random_forest_classifier)
 register_converter("SklearnExtraTreesRegressor", convert_sklearn_random_forest_regressor)
+register_converter("SklearnRandomForestClassifier", convert_sklearn_random_forest_classifier)
+register_converter("SklearnRandomForestRegressor", convert_sklearn_random_forest_regressor)

--- a/hummingbird/ml/supported.py
+++ b/hummingbird/ml/supported.py
@@ -12,6 +12,7 @@ PyTorch
 
 **Supported Operators**
 DecisionTreeClassifier,
+DecisionTreeRegressor,
 RandomForestClassifier,
 RandomForestRegressor,
 GradientBoostingClassifier,
@@ -45,11 +46,12 @@ def _build_sklearn_operator_list():
             ExtraTreesClassifier,
             ExtraTreesRegressor,
         )
-        from sklearn.tree import DecisionTreeClassifier
+        from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
         return [
             # Tree-methods
             DecisionTreeClassifier,
+            DecisionTreeRegressor,
             RandomForestClassifier,
             RandomForestRegressor,
             GradientBoostingClassifier,

--- a/hummingbird/ml/supported.py
+++ b/hummingbird/ml/supported.py
@@ -13,12 +13,12 @@ PyTorch
 **Supported Operators**
 DecisionTreeClassifier,
 DecisionTreeRegressor,
-RandomForestClassifier,
-RandomForestRegressor,
-GradientBoostingClassifier,
-GradientBoostingRegressor,
 ExtraTreesClassifier,
 ExtraTreesRegressor,
+GradientBoostingClassifier,
+GradientBoostingRegressor,
+RandomForestClassifier,
+RandomForestRegressor,
 LGBMClassifier,
 LGBMRegressor,
 XGBClassifier,
@@ -39,12 +39,12 @@ def _build_sklearn_operator_list():
     if sklearn_installed():
         # Tree-based models
         from sklearn.ensemble import (
-            RandomForestClassifier,
-            RandomForestRegressor,
-            GradientBoostingClassifier,
-            GradientBoostingRegressor,
             ExtraTreesClassifier,
             ExtraTreesRegressor,
+            GradientBoostingClassifier,
+            GradientBoostingRegressor,
+            RandomForestClassifier,
+            RandomForestRegressor,
         )
         from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
@@ -52,12 +52,12 @@ def _build_sklearn_operator_list():
             # Tree-methods
             DecisionTreeClassifier,
             DecisionTreeRegressor,
-            RandomForestClassifier,
-            RandomForestRegressor,
-            GradientBoostingClassifier,
-            GradientBoostingRegressor,
             ExtraTreesClassifier,
             ExtraTreesRegressor,
+            GradientBoostingClassifier,
+            GradientBoostingRegressor,
+            RandomForestClassifier,
+            RandomForestRegressor,
         ]
 
     return None

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -113,40 +113,11 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_random_forest_perf_tree_trav_regressor_converter(self):
         self._run_random_forest_regressor_converter(1000, extra_config={"tree_implementation": "perf_tree_trav"})
 
-    def _run_extra_trees_regressor_converter(self, num_classes, extra_config={}):
-        warnings.filterwarnings("ignore")
-        for max_depth in [1, 3, 8, 10, 12, None]:
-            model = ExtraTreesRegressor(n_estimators=10, max_depth=max_depth)
-            X = np.random.rand(100, 200)
-            X = np.array(X, dtype=np.float32)
-            y = np.random.randint(num_classes, size=100)
-
-            model.fit(X, y)
-            pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
-            np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
-
-    # Regressor
-    def test_extra_trees_regressor_converter(self):
-        self._run_extra_trees_regressor_converter(1000)
-
-    # Gemm regressor
-    def test_extra_trees_gemm_regressor_converter(self):
-        self._run_extra_trees_regressor_converter(1000, extra_config={"tree_implementation": "gemm"})
-
-    # Tree_trav regressor
-    def test_extra_trees_tree_trav_regressor_converter(self):
-        self._run_extra_trees_regressor_converter(1000, extra_config={"tree_implementation": "tree_trav"})
-
-    # Perf_tree_trav regressor
-    def test_extra_trees_perf_tree_trav_regressor_converter(self):
-        self._run_extra_trees_regressor_converter(1000, extra_config={"tree_implementation": "perf_tree_trav"})
-
     # Used for regression tests
-    def _run_tree_regressor_converter(self, model_type, num_classes, extra_config={}):
+    def _run_tree_regressor_converter(self, model_type, num_classes, extra_config={}, **kwargs):
         warnings.filterwarnings("ignore")
         for max_depth in [1, 3, 8, 10, 12, None]:
-            model = model_type(max_depth=max_depth)
+            model = model_type(max_depth=max_depth, **kwargs)
             X = np.random.rand(100, 200)
             X = np.array(X, dtype=np.float32)
             y = np.random.randint(num_classes, size=100)
@@ -155,6 +126,22 @@ class TestSklearnTreeConverter(unittest.TestCase):
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
             self.assertTrue(pytorch_model is not None)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
+
+    # Extra trees regressor
+    def test_extra_trees_regressor_converter(self):
+        self._run_tree_regressor_converter(ExtraTreesRegressor, 1000, n_estimators=10)
+
+    # Extra trees gemm regressor
+    def test_extra_trees_gemm_regressor_converter(self):
+        self._run_tree_regressor_converter(ExtraTreesRegressor, 1000, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
+
+    # Extra trees tree_trav regressor
+    def test_extra_trees_tree_trav_regressor_converter(self):
+        self._run_tree_regressor_converter(ExtraTreesRegressor, 1000, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
+
+    # Extra trees perf_tree_trav regressor
+    def test_extra_trees_perf_tree_trav_regressor_converter(self):
+        self._run_tree_regressor_converter(ExtraTreesRegressor, 1000, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Decision tree regressor
     def test_decision_tree_regressor_converter(self):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -142,12 +142,11 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_extra_trees_perf_tree_trav_regressor_converter(self):
         self._run_extra_trees_regressor_converter(1000, extra_config={"tree_implementation": "perf_tree_trav"})
 
-    # Used for DecisionTreeRegressor
-    def _run_decision_tree_regressor_converter(self, num_classes, extra_config={}):
-        # TODO: Extract method so that this can be reused across regressors.
+    # Used for regression tests
+    def _run_tree_regressor_converter(self, model_type, num_classes, extra_config={}):
         warnings.filterwarnings("ignore")
         for max_depth in [1, 3, 8, 10, 12, None]:
-            model = DecisionTreeRegressor(max_depth=max_depth)
+            model = model_type(max_depth=max_depth)
             X = np.random.rand(100, 200)
             X = np.array(X, dtype=np.float32)
             y = np.random.randint(num_classes, size=100)
@@ -157,21 +156,21 @@ class TestSklearnTreeConverter(unittest.TestCase):
             self.assertTrue(pytorch_model is not None)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
 
-    # Regressor
+    # Decision tree regressor
     def test_decision_tree_regressor_converter(self):
-        self._run_decision_tree_regressor_converter(1000)
+        self._run_tree_regressor_converter(DecisionTreeRegressor, 1000)
 
-    # Gemm regressor
+    # Decision tree gemm regressor
     def test_decision_tree_gemm_regressor_converter(self):
-        self._run_decision_tree_regressor_converter(1000, extra_config={"tree_implementation": "gemm"})
+        self._run_tree_regressor_converter(DecisionTreeRegressor, 1000, extra_config={"tree_implementation": "gemm"})
 
-    # Tree_trav regressor
+    # Decision tree tree_trav regressor
     def test_decision_tree_tree_trav_regressor_converter(self):
-        self._run_decision_tree_regressor_converter(1000, extra_config={"tree_implementation": "tree_trav"})
+        self._run_tree_regressor_converter(DecisionTreeRegressor, 1000, extra_config={"tree_implementation": "tree_trav"})
 
-    # Perf_tree_trav regressor
+    # Decision tree perf_tree_trav regressor
     def test_decision_tree_perf_tree_trav_regressor_converter(self):
-        self._run_decision_tree_regressor_converter(1000, extra_config={"tree_implementation": "perf_tree_trav"})
+        self._run_tree_regressor_converter(DecisionTreeRegressor, 1000, extra_config={"tree_implementation": "perf_tree_trav"})
 
     # Used for DecisionTreeClassifier and ExtraTreesClassifier
     def _run_test_other_trees_classifier(self, model):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -5,7 +5,7 @@ import unittest
 import warnings
 
 import numpy as np
-from sklearn.ensemble import RandomForestClassifier, RandomForestRegressor, ExtraTreesClassifier, ExtraTreesRegressor
+from sklearn.ensemble import ExtraTreesClassifier, ExtraTreesRegressor, RandomForestClassifier, RandomForestRegressor
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 import hummingbird.ml
@@ -13,7 +13,7 @@ from hummingbird.ml.exceptions import MissingConverter
 from tree_utils import dt_implementation_map
 
 
-class TestSklearnRandomForestConverter(unittest.TestCase):
+class TestSklearnTreeConverter(unittest.TestCase):
     # Check tree implementation
     def test_random_forest_implementation(self):
         warnings.filterwarnings("ignore")

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -84,35 +84,6 @@ class TestSklearnTreeConverter(unittest.TestCase):
         self._run_random_forest_classifier_converter(3, labels_shift=2, extra_config={"tree_implementation": "tree_trav"})
         self._run_random_forest_classifier_converter(3, labels_shift=2, extra_config={"tree_implementation": "perf_tree_trav"})
 
-    def _run_random_forest_regressor_converter(self, num_classes, extra_config={}):
-        warnings.filterwarnings("ignore")
-        for max_depth in [1, 3, 8, 10, 12, None]:
-            model = RandomForestRegressor(n_estimators=10, max_depth=max_depth)
-            X = np.random.rand(100, 200)
-            X = np.array(X, dtype=np.float32)
-            y = np.random.randint(num_classes, size=100)
-
-            model.fit(X, y)
-            pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
-            np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
-
-    # Regressor
-    def test_random_forest_regressor_converter(self):
-        self._run_random_forest_regressor_converter(1000)
-
-    # Gemm regressor
-    def test_random_forest_gemm_regressor_converter(self):
-        self._run_random_forest_regressor_converter(1000, extra_config={"tree_implementation": "gemm"})
-
-    # Tree_trav regressor
-    def test_random_forest_tree_trav_regressor_converter(self):
-        self._run_random_forest_regressor_converter(1000, extra_config={"tree_implementation": "tree_trav"})
-
-    # Perf_tree_trav regressor
-    def test_random_forest_perf_tree_trav_regressor_converter(self):
-        self._run_random_forest_regressor_converter(1000, extra_config={"tree_implementation": "perf_tree_trav"})
-
     # Used for regression tests
     def _run_tree_regressor_converter(self, model_type, num_classes, extra_config={}, **kwargs):
         warnings.filterwarnings("ignore")
@@ -126,6 +97,22 @@ class TestSklearnTreeConverter(unittest.TestCase):
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
             self.assertTrue(pytorch_model is not None)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
+
+    # Random forest regressor
+    def test_random_forest_regressor_converter(self):
+        self._run_tree_regressor_converter(RandomForestRegressor, 1000, n_estimators=10)
+
+    # Random forest gemm regressor
+    def test_random_forest_gemm_regressor_converter(self):
+        self._run_tree_regressor_converter(RandomForestRegressor, 1000, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
+
+    # Random forest tree_trav regressor
+    def test_random_forest_tree_trav_regressor_converter(self):
+        self._run_tree_regressor_converter(RandomForestRegressor, 1000, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
+
+    # Random forest perf_tree_trav regressor
+    def test_random_forest_perf_tree_trav_regressor_converter(self):
+        self._run_tree_regressor_converter(RandomForestRegressor, 1000, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Extra trees regressor
     def test_extra_trees_regressor_converter(self):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -147,7 +147,7 @@ class TestSklearnRandomForestConverter(unittest.TestCase):
         # TODO: Extract method so that this can be reused across regressors.
         warnings.filterwarnings("ignore")
         for max_depth in [1, 3, 8, 10, 12, None]:
-            model = DecisionTreeRegressor(n_estimators=10, max_depth=max_depth)
+            model = DecisionTreeRegressor(max_depth=max_depth)
             X = np.random.rand(100, 200)
             X = np.array(X, dtype=np.float32)
             y = np.random.randint(num_classes, size=100)


### PR DESCRIPTION
(Fix for #98)

In this PR:
- Register decision tree (DT) regressor as a supported sklearn operator
- Add tests for DT regression
- Leverage random forests regression converter in convert_sklearn_decision_tree_regressor 

Validated that the tests pass locally.