### PR TITLE
Improve converter documentation and add decision tree regressor docs

### DIFF
--- a/doc/html/hummingbird/ml/convert.html
+++ b/doc/html/hummingbird/ml/convert.html
@@ -68,14 +68,14 @@ def _supported_backend_check(backend):
 def _convert_sklearn(model, test_input=None, extra_config={}):
     &#34;&#34;&#34;
     This function converts the specified *scikit-learn* (API) model into its [PyTorch] counterpart.
-    The supported operators can be found at `hummingbird.supported`.
+    The supported operators can be found at `hummingbird.ml.supported`.
     [PyTorch]: https://pytorch.org/
 
     Args:
         model: A scikit-learn model
         test_input: some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         &gt;&gt;&gt; pytorch_model = _convert_sklearn(sklearn_model)
@@ -106,7 +106,7 @@ def _convert_lightgbm(model, test_input=None, extra_config={}):
         model: A LightGBM model (trained using the scikit-learn API)
         test_input: Some input data that will be used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         &gt;&gt;&gt; pytorch_model = _convert_lightgbm(lgbm_model)
@@ -129,7 +129,7 @@ def _convert_xgboost(model, test_input, extra_config={}):
         model: A XGBoost model (trained using the scikit-learn API)
         test_input: Some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         &gt;&gt;&gt; pytorch_model = _convert_xgboost(xgb_model, [], extra_config={&#34;n_features&#34;:200})
@@ -203,8 +203,8 @@ def convert(model, backend, test_input=None, extra_config={}):
     &#34;&#34;&#34;
     This function converts the specified input *model* into an implementation targeting *backend*.
     *Convert* supports [Sklearn], [LightGBM] and [XGBoost] models.
-    For *LightGBM* and *XGBoost currently only the Sklearn API is supported.
-    The detailed list of models and backends can be found at `hummingbird.supported`.
+    For *LightGBM* and *XGBoost* currently only the Sklearn API is supported.
+    The detailed list of models and backends can be found at `hummingbird.ml.supported`.
     [Sklearn]: https://scikit-learn.org/
     [LightGBM]: https://lightgbm.readthedocs.io/
     [XGBoost]: https://xgboost.readthedocs.io/
@@ -214,7 +214,7 @@ def convert(model, backend, test_input=None, extra_config={}):
         backend: The target for the conversion
         test_input: some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         &gt;&gt;&gt; pytorch_model = convert(sklearn_model,`pytorch`)
@@ -246,8 +246,8 @@ def convert(model, backend, test_input=None, extra_config={}):
 <dd>
 <div class="desc"><p>This function converts the specified input <em>model</em> into an implementation targeting <em>backend</em>.
 <em>Convert</em> supports <a href="https://scikit-learn.org/">Sklearn</a>, <a href="https://lightgbm.readthedocs.io/">LightGBM</a> and <a href="https://xgboost.readthedocs.io/">XGBoost</a> models.
-For <em>LightGBM</em> and *XGBoost currently only the Sklearn API is supported.
-The detailed list of models and backends can be found at <code>hummingbird.supported</code>.</p>
+For <em>LightGBM</em> and <em>XGBoost</em> currently only the Sklearn API is supported.
+The detailed list of models and backends can be found at <code><a title="hummingbird.ml.supported" href="supported.html">hummingbird.ml.supported</a></code>.</p>
 <h2 id="args">Args</h2>
 <dl>
 <dt><strong><code>model</code></strong></dt>
@@ -258,7 +258,7 @@ The detailed list of models and backends can be found at <code>hummingbird.suppo
 <dd>some input data used to trace the model execution</dd>
 <dt><strong><code>extra_config</code></strong></dt>
 <dd>Extra configurations to be used by the individual operator converters.
-The set of supported extra configurations can be found at <code>hummingbird.supported_configurations</code></dd>
+The set of supported extra configurations can be found at <code><a title="hummingbird.ml.supported" href="supported.html">hummingbird.ml.supported</a></code></dd>
 </dl>
 <h2 id="examples">Examples</h2>
 <pre><code class="python">&gt;&gt;&gt; pytorch_model = convert(sklearn_model,&lt;code&gt;pytorch&lt;/code&gt;)
@@ -273,8 +273,8 @@ The set of supported extra configurations can be found at <code>hummingbird.supp
     &#34;&#34;&#34;
     This function converts the specified input *model* into an implementation targeting *backend*.
     *Convert* supports [Sklearn], [LightGBM] and [XGBoost] models.
-    For *LightGBM* and *XGBoost currently only the Sklearn API is supported.
-    The detailed list of models and backends can be found at `hummingbird.supported`.
+    For *LightGBM* and *XGBoost* currently only the Sklearn API is supported.
+    The detailed list of models and backends can be found at `hummingbird.ml.supported`.
     [Sklearn]: https://scikit-learn.org/
     [LightGBM]: https://lightgbm.readthedocs.io/
     [XGBoost]: https://xgboost.readthedocs.io/
@@ -284,7 +284,7 @@ The set of supported extra configurations can be found at <code>hummingbird.supp
         backend: The target for the conversion
         test_input: some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         &gt;&gt;&gt; pytorch_model = convert(sklearn_model,`pytorch`)

--- a/doc/html/hummingbird/ml/operator_converters/decision_tree.html
+++ b/doc/html/hummingbird/ml/operator_converters/decision_tree.html
@@ -235,12 +235,31 @@ def convert_sklearn_decision_tree_classifier(operator, device, extra_config):
     return convert_sklearn_random_forest_classifier(operator, device, extra_config)
 
 
+def convert_sklearn_decision_tree_regressor(operator, device, extra_config):
+    &#34;&#34;&#34;
+    Converter for `sklearn.tree.DecisionTreeRegressor`.
+
+    Args:
+        operator: An operator wrapping a `sklearn.tree.DecisionTreeRegressor` model
+        device: String defining the type of device the converted operator should be run on
+        extra_config: Extra configuration used to select the best conversion strategy
+
+    Returns:
+        A PyTorch model
+    &#34;&#34;&#34;
+    assert operator is not None
+
+    operator.raw_operator.estimators_ = [operator.raw_operator]
+    return convert_sklearn_random_forest_regressor(operator, device, extra_config)
+
+
 # Register the converters.
-register_converter(&#34;SklearnRandomForestClassifier&#34;, convert_sklearn_random_forest_classifier)
-register_converter(&#34;SklearnRandomForestRegressor&#34;, convert_sklearn_random_forest_regressor)
 register_converter(&#34;SklearnDecisionTreeClassifier&#34;, convert_sklearn_decision_tree_classifier)
+register_converter(&#34;SklearnDecisionTreeRegressor&#34;, convert_sklearn_decision_tree_regressor)
 register_converter(&#34;SklearnExtraTreesClassifier&#34;, convert_sklearn_random_forest_classifier)
-register_converter(&#34;SklearnExtraTreesRegressor&#34;, convert_sklearn_random_forest_regressor)</code></pre>
+register_converter(&#34;SklearnExtraTreesRegressor&#34;, convert_sklearn_random_forest_regressor)
+register_converter(&#34;SklearnRandomForestClassifier&#34;, convert_sklearn_random_forest_classifier)
+register_converter(&#34;SklearnRandomForestRegressor&#34;, convert_sklearn_random_forest_regressor)</code></pre>
 </details>
 </section>
 <section>
@@ -289,6 +308,47 @@ register_converter(&#34;SklearnExtraTreesRegressor&#34;, convert_sklearn_random_
 
     operator.raw_operator.estimators_ = [operator.raw_operator]
     return convert_sklearn_random_forest_classifier(operator, device, extra_config)</code></pre>
+</details>
+</dd>
+<dt id="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_decision_tree_regressor"><code class="name flex">
+<span>def <span class="ident">convert_sklearn_decision_tree_regressor</span></span>(<span>operator, device, extra_config)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Converter for <code>sklearn.tree.DecisionTreeRegressor</code>.</p>
+<h2 id="args">Args</h2>
+<dl>
+<dt><strong><code>operator</code></strong></dt>
+<dd>An operator wrapping a <code>sklearn.tree.DecisionTreeRegressor</code> model</dd>
+<dt><strong><code>device</code></strong></dt>
+<dd>String defining the type of device the converted operator should be run on</dd>
+<dt><strong><code>extra_config</code></strong></dt>
+<dd>Extra configuration used to select the best conversion strategy</dd>
+</dl>
+<h2 id="returns">Returns</h2>
+<dl>
+<dt><code>A PyTorch model</code></dt>
+<dd>&nbsp;</dd>
+</dl></div>
+<details class="source">
+<summary>
+<span>Expand source code</span>
+</summary>
+<pre><code class="python">def convert_sklearn_decision_tree_regressor(operator, device, extra_config):
+    &#34;&#34;&#34;
+    Converter for `sklearn.tree.DecisionTreeRegressor`.
+
+    Args:
+        operator: An operator wrapping a `sklearn.tree.DecisionTreeRegressor` model
+        device: String defining the type of device the converted operator should be run on
+        extra_config: Extra configuration used to select the best conversion strategy
+
+    Returns:
+        A PyTorch model
+    &#34;&#34;&#34;
+    assert operator is not None
+
+    operator.raw_operator.estimators_ = [operator.raw_operator]
+    return convert_sklearn_random_forest_regressor(operator, device, extra_config)</code></pre>
 </details>
 </dd>
 <dt id="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_random_forest_classifier"><code class="name flex">
@@ -709,6 +769,7 @@ register_converter(&#34;SklearnExtraTreesRegressor&#34;, convert_sklearn_random_
 <li><h3><a href="#header-functions">Functions</a></h3>
 <ul class="">
 <li><code><a title="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_decision_tree_classifier" href="#hummingbird.ml.operator_converters.decision_tree.convert_sklearn_decision_tree_classifier">convert_sklearn_decision_tree_classifier</a></code></li>
+<li><code><a title="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_decision_tree_regressor" href="#hummingbird.ml.operator_converters.decision_tree.convert_sklearn_decision_tree_regressor">convert_sklearn_decision_tree_regressor</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_random_forest_classifier" href="#hummingbird.ml.operator_converters.decision_tree.convert_sklearn_random_forest_classifier">convert_sklearn_random_forest_classifier</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.decision_tree.convert_sklearn_random_forest_regressor" href="#hummingbird.ml.operator_converters.decision_tree.convert_sklearn_random_forest_regressor">convert_sklearn_random_forest_regressor</a></code></li>
 </ul>

--- a/doc/html/hummingbird/ml/supported.html
+++ b/doc/html/hummingbird/ml/supported.html
@@ -28,12 +28,13 @@
 PyTorch</p>
 <p><strong>Supported Operators</strong>
 DecisionTreeClassifier,
-RandomForestClassifier,
-RandomForestRegressor,
-GradientBoostingClassifier,
-GradientBoostingRegressor,
+DecisionTreeRegressor,
 ExtraTreesClassifier,
 ExtraTreesRegressor,
+GradientBoostingClassifier,
+GradientBoostingRegressor,
+RandomForestClassifier,
+RandomForestRegressor,
 LGBMClassifier,
 LGBMRegressor,
 XGBClassifier,
@@ -56,12 +57,13 @@ PyTorch
 
 **Supported Operators**
 DecisionTreeClassifier,
-RandomForestClassifier,
-RandomForestRegressor,
-GradientBoostingClassifier,
-GradientBoostingRegressor,
+DecisionTreeRegressor,
 ExtraTreesClassifier,
 ExtraTreesRegressor,
+GradientBoostingClassifier,
+GradientBoostingRegressor,
+RandomForestClassifier,
+RandomForestRegressor,
 LGBMClassifier,
 LGBMRegressor,
 XGBClassifier,
@@ -82,24 +84,25 @@ def _build_sklearn_operator_list():
     if sklearn_installed():
         # Tree-based models
         from sklearn.ensemble import (
-            RandomForestClassifier,
-            RandomForestRegressor,
-            GradientBoostingClassifier,
-            GradientBoostingRegressor,
             ExtraTreesClassifier,
             ExtraTreesRegressor,
+            GradientBoostingClassifier,
+            GradientBoostingRegressor,
+            RandomForestClassifier,
+            RandomForestRegressor,
         )
-        from sklearn.tree import DecisionTreeClassifier
+        from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
         return [
             # Tree-methods
             DecisionTreeClassifier,
-            RandomForestClassifier,
-            RandomForestRegressor,
-            GradientBoostingClassifier,
-            GradientBoostingRegressor,
+            DecisionTreeRegressor,
             ExtraTreesClassifier,
             ExtraTreesRegressor,
+            GradientBoostingClassifier,
+            GradientBoostingRegressor,
+            RandomForestClassifier,
+            RandomForestRegressor,
         ]
 
     return None

--- a/hummingbird/ml/convert.py
+++ b/hummingbird/ml/convert.py
@@ -38,14 +38,14 @@ def _supported_backend_check(backend):
 def _convert_sklearn(model, test_input=None, extra_config={}):
     """
     This function converts the specified *scikit-learn* (API) model into its [PyTorch] counterpart.
-    The supported operators can be found at `hummingbird.supported`.
+    The supported operators can be found at `hummingbird.ml.supported`.
     [PyTorch]: https://pytorch.org/
 
     Args:
         model: A scikit-learn model
         test_input: some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         >>> pytorch_model = _convert_sklearn(sklearn_model)
@@ -76,7 +76,7 @@ def _convert_lightgbm(model, test_input=None, extra_config={}):
         model: A LightGBM model (trained using the scikit-learn API)
         test_input: Some input data that will be used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         >>> pytorch_model = _convert_lightgbm(lgbm_model)
@@ -99,7 +99,7 @@ def _convert_xgboost(model, test_input, extra_config={}):
         model: A XGBoost model (trained using the scikit-learn API)
         test_input: Some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         >>> pytorch_model = _convert_xgboost(xgb_model, [], extra_config={"n_features":200})
@@ -173,8 +173,8 @@ def convert(model, backend, test_input=None, extra_config={}):
     """
     This function converts the specified input *model* into an implementation targeting *backend*.
     *Convert* supports [Sklearn], [LightGBM] and [XGBoost] models.
-    For *LightGBM* and *XGBoost currently only the Sklearn API is supported.
-    The detailed list of models and backends can be found at `hummingbird.supported`.
+    For *LightGBM* and *XGBoost* currently only the Sklearn API is supported.
+    The detailed list of models and backends can be found at `hummingbird.ml.supported`.
     [Sklearn]: https://scikit-learn.org/
     [LightGBM]: https://lightgbm.readthedocs.io/
     [XGBoost]: https://xgboost.readthedocs.io/
@@ -184,7 +184,7 @@ def convert(model, backend, test_input=None, extra_config={}):
         backend: The target for the conversion
         test_input: some input data used to trace the model execution
         extra_config: Extra configurations to be used by the individual operator converters.
-                      The set of supported extra configurations can be found at `hummingbird.supported_configurations`
+                      The set of supported extra configurations can be found at `hummingbird.ml.supported`
 
     Examples:
         >>> pytorch_model = convert(sklearn_model,`pytorch`)


### PR DESCRIPTION
Fixes #104 

In this PR:
- We improve the documentation of converter such that it correctly references hummingbird.ml.supported.
- Also add decision tree regressor documentation i.e. do a doc refresh in the repository (not actual gh-pages)

Validations:
- `supported` is correctly referenced and is a link now in docs.
- Decision tree documentation is updated.