### PR TITLE
Update build status badge to represent master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Hummingbird
 
 [![PyPI version](https://badge.fury.io/py/hummingbird-ml.svg)](https://badge.fury.io/py/hummingbird-ml)
-![](https://github.com/microsoft/hummingbird/workflows/Python%20application/badge.svg?branch=develop)
+![](https://github.com/microsoft/hummingbird/workflows/Python%20application/badge.svg?branch=master)
 ![](https://img.shields.io/badge/python-3.5%20%7C%203.6%20%7C%203.7%20%7C%203.8-blue)
 [![coverage](https://codecov.io/gh/microsoft/hummingbird/branch/master/graph/badge.svg)](https://codecov.io/github/microsoft/hummingbird?branch=master)
 [![Gitter](https://badges.gitter.im/hummingbird-ml/community.svg)](https://gitter.im/hummingbird-ml/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)


### PR DESCRIPTION
Fixes #110 

- Build status badge represents `develop` branch currently
- However, code coverage is shown for `master`
- Both the badges should represent the same branch.

This PR:
- Update build status badge to represent `master` branch