### PR TITLE
 Refactor tree classifier tests

### DIFF
--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -79,10 +79,16 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_random_forest_perf_tree_trav_multi_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
-    # Random forest shifted classes
-    def test_random_forest_classifier_shifted_labels_converter(self):
+    # Random forest gemm classifier shifted classes
+    def test_random_forest_gemm_classifier_shifted_labels_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
+
+    # Random forest tree_trav classifier shifted classes
+    def test_random_forest_tree_trav_classifier_shifted_labels_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
+
+    # Random forest perf_tree_trav classifier shifted classes
+    def test_random_forest_perf_tree_trav_classifier_shifted_labels_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Used for regression tests

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -33,6 +33,20 @@ class TestSklearnTreeConverter(unittest.TestCase):
                     str(type(list(pytorch_model.operator_map.values())[0])) == dt_implementation_map[extra_config_param]
                 )
 
+    # Used for classification tests
+    def _run_tree_classification_converter(self, model_type, num_classes, extra_config={}, labels_shift=0, **kwargs):
+        warnings.filterwarnings("ignore")
+        for max_depth in [1, 3, 8, 10, 12, None]:
+            X = np.random.rand(100, 200)
+            X = np.array(X, dtype=np.float32)
+            y = np.random.randint(num_classes, size=100) + labels_shift
+
+            model = model_type(max_depth=max_depth, **kwargs)
+            model.fit(X, y)
+            pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
+            self.assertTrue(pytorch_model is not None)
+            np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
+
     def _run_random_forest_classifier_converter(self, num_classes, extra_config={}, labels_shift=0):
         warnings.filterwarnings("ignore")
         for max_depth in [1, 3, 8, 10, 12, None]:
@@ -146,27 +160,11 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_decision_tree_perf_tree_trav_regressor_converter(self):
         self._run_tree_regressor_converter(DecisionTreeRegressor, 1000, extra_config={"tree_implementation": "perf_tree_trav"})
 
-    # Used for DecisionTreeClassifier and ExtraTreesClassifier
-    def _run_test_other_trees_classifier(self, model):
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(3, size=100)
-
-        model.fit(X, y)
-        pytorch_model = hummingbird.ml.convert(model, "pytorch")
-        self.assertTrue(pytorch_model is not None)
-        np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
-
     def test_decision_tree_classifier_converter(self):
-        for max_depth in [1, 3, 8, 10, 12, None]:
-            model = DecisionTreeClassifier(max_depth=max_depth)
-            self._run_test_other_trees_classifier(model)
+        self._run_tree_classification_converter(DecisionTreeClassifier, 3)
 
     def test_extra_trees_classifier_converter(self):
-        warnings.filterwarnings("ignore")
-        for max_depth in [1, 3, 8, 10, 12, None]:
-            model = ExtraTreesClassifier(n_estimators=10, max_depth=max_depth)
-            self._run_test_other_trees_classifier(model)
+        self._run_tree_classification_converter(ExtraTreesClassifier, 3, n_estimators=10)
 
     # Small tree
     def test_random_forest_classifier_single_node_tree_converter(self):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -47,39 +47,39 @@ class TestSklearnTreeConverter(unittest.TestCase):
             self.assertTrue(pytorch_model is not None)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
-    # Binary classifier
+    # Random forest binary classifier
     def test_random_forest_classifier_binary_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 2, n_estimators=10)
 
-    # Gemm classifier
+    # Random forest gemm classifier
     def test_random_forest_gemm_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
 
-    # Tree_trav classifier
+    # Random forest tree_trav classifier
     def test_random_forest_tree_trav_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
 
-    # Perf_tree_trav classifier
+    # Random forest perf_tree_trav classifier
     def test_random_forest_perf_tree_trav_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
-    # Multi classifier
+    # Random forest multi classifier
     def test_random_forest_multi_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, n_estimators=10)
 
-    # Gemm multi classifier
+    # Random forest gemm multi classifier
     def test_random_forest_gemm_multi_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
 
-    # Tree_trav multi classifier
+    # Random forest tree_trav multi classifier
     def test_random_forest_tree_trav_multi_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
 
-    # Perf_tree_trav multi classifier
+    # Random forest perf_tree_trav multi classifier
     def test_random_forest_perf_tree_trav_multi_classifier_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
-    # Shifted classes
+    # Random forest shifted classes
     def test_random_forest_classifier_shifted_labels_converter(self):
         self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
         self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
@@ -147,9 +147,11 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_decision_tree_perf_tree_trav_regressor_converter(self):
         self._run_tree_regressor_converter(DecisionTreeRegressor, 1000, extra_config={"tree_implementation": "perf_tree_trav"})
 
+    # Decision tree classifier
     def test_decision_tree_classifier_converter(self):
         self._run_tree_classification_converter(DecisionTreeClassifier, 3)
 
+    # Extra trees classifier
     def test_extra_trees_classifier_converter(self):
         self._run_tree_classification_converter(ExtraTreesClassifier, 3, n_estimators=10)
 

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -161,17 +161,28 @@ class TestSklearnTreeConverter(unittest.TestCase):
     def test_extra_trees_classifier_converter(self):
         self._run_tree_classification_converter(ExtraTreesClassifier, 3, n_estimators=10)
 
-    # Small tree
-    def test_random_forest_classifier_single_node_tree_converter(self):
+    # Used for small tree tests
+    def _run_random_forest_classifier_single_node_tree_converter(self, extra_config={}):
         warnings.filterwarnings("ignore")
-        for extra_config_param in ["tree_trav", "perf_tree_trav", "gemm"]:
-            X = np.random.rand(1, 1)
-            X = np.array(X, dtype=np.float32)
-            y = np.random.randint(1, size=1)
-            model = RandomForestClassifier(n_estimators=1).fit(X, y)
-            pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config={"tree_implementation": extra_config_param})
-            self.assertTrue(pytorch_model is not None)
-            np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
+        X = np.random.rand(1, 1)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(1, size=1)
+        model = RandomForestClassifier(n_estimators=1).fit(X, y)
+        pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
+        self.assertTrue(pytorch_model is not None)
+        np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
+
+    # Small tree gemm implementation
+    def test_random_forest_gemm_classifier_single_node_tree_converter(self):
+        self._run_random_forest_classifier_single_node_tree_converter(extra_config={"tree_implementation": "gemm"})
+
+    # Small tree tree_trav implementation
+    def test_random_forest_tree_trav_classifier_single_node_tree_converter(self):
+        self._run_random_forest_classifier_single_node_tree_converter(extra_config={"tree_implementation": "tree_trav"})
+
+    # Small tree perf_tree_trav implementation
+    def test_random_forest_perf_tree_trav_classifier_single_node_tree_converter(self):
+        self._run_random_forest_classifier_single_node_tree_converter(extra_config={"tree_implementation": "perf_tree_trav"})
 
     # Failure Cases
     def test_random_forest_classifier_raises_wrong_type(self):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -47,56 +47,43 @@ class TestSklearnTreeConverter(unittest.TestCase):
             self.assertTrue(pytorch_model is not None)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
-    def _run_random_forest_classifier_converter(self, num_classes, extra_config={}, labels_shift=0):
-        warnings.filterwarnings("ignore")
-        for max_depth in [1, 3, 8, 10, 12, None]:
-            model = RandomForestClassifier(n_estimators=10, max_depth=max_depth)
-            X = np.random.rand(100, 200)
-            X = np.array(X, dtype=np.float32)
-            y = np.random.randint(num_classes, size=100) + labels_shift
-
-            model.fit(X, y)
-            pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
-            np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
-
     # Binary classifier
     def test_random_forest_classifier_binary_converter(self):
-        self._run_random_forest_classifier_converter(2)
+        self._run_tree_classification_converter(RandomForestClassifier, 2, n_estimators=10)
 
     # Gemm classifier
     def test_random_forest_gemm_classifier_converter(self):
-        self._run_random_forest_classifier_converter(2, extra_config={"tree_implementation": "gemm"})
+        self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
 
     # Tree_trav classifier
     def test_random_forest_tree_trav_classifier_converter(self):
-        self._run_random_forest_classifier_converter(2, extra_config={"tree_implementation": "tree_trav"})
+        self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
 
     # Perf_tree_trav classifier
     def test_random_forest_perf_tree_trav_classifier_converter(self):
-        self._run_random_forest_classifier_converter(2, extra_config={"tree_implementation": "perf_tree_trav"})
+        self._run_tree_classification_converter(RandomForestClassifier, 2, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Multi classifier
     def test_random_forest_multi_classifier_converter(self):
-        self._run_random_forest_classifier_converter(3)
+        self._run_tree_classification_converter(RandomForestClassifier, 3, n_estimators=10)
 
     # Gemm multi classifier
     def test_random_forest_gemm_multi_classifier_converter(self):
-        self._run_random_forest_classifier_converter(3, extra_config={"tree_implementation": "gemm"})
+        self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
 
     # Tree_trav multi classifier
     def test_random_forest_tree_trav_multi_classifier_converter(self):
-        self._run_random_forest_classifier_converter(3, extra_config={"tree_implementation": "tree_trav"})
+        self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
 
     # Perf_tree_trav multi classifier
     def test_random_forest_perf_tree_trav_multi_classifier_converter(self):
-        self._run_random_forest_classifier_converter(3, extra_config={"tree_implementation": "perf_tree_trav"})
+        self._run_tree_classification_converter(RandomForestClassifier, 3, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Shifted classes
     def test_random_forest_classifier_shifted_labels_converter(self):
-        self._run_random_forest_classifier_converter(3, labels_shift=2, extra_config={"tree_implementation": "gemm"})
-        self._run_random_forest_classifier_converter(3, labels_shift=2, extra_config={"tree_implementation": "tree_trav"})
-        self._run_random_forest_classifier_converter(3, labels_shift=2, extra_config={"tree_implementation": "perf_tree_trav"})
+        self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "gemm"}, n_estimators=10)
+        self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "tree_trav"}, n_estimators=10)
+        self._run_tree_classification_converter(RandomForestClassifier, 3, labels_shift=2, extra_config={"tree_implementation": "perf_tree_trav"}, n_estimators=10)
 
     # Used for regression tests
     def _run_tree_regressor_converter(self, model_type, num_classes, extra_config={}, **kwargs):


### PR DESCRIPTION
Addresses #108 

This PR:
- We extract common code of various tree classifiers into a new method and use it across.
- No "functional" changes made to tests

I feel we could do more but I'm unsure whether or not to proceed further. Overall, the current state looks good enough.
There are some specific tests such as single node, wrong data type that are left untouched.

Validation:
- All tests pass locally.