### PR TITLE
Update assert usage in tests for readability

### DIFF
--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -25,7 +25,7 @@ class TestBackends(unittest.TestCase):
         model.fit(X, y)
 
         hb_model = hummingbird.ml.convert(model, "pYtOrCh")
-        self.assertTrue(hb_model is not None)
+        self.assertIsNotNone(hb_model)
         np.testing.assert_allclose(model.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
     # Test not supported backends

--- a/tests/test_lightgbm_converters.py
+++ b/tests/test_lightgbm_converters.py
@@ -26,7 +26,7 @@ class TestLGBMConverter(unittest.TestCase):
                 pytorch_model = hummingbird.ml.convert(
                     model, "pytorch", extra_config={"tree_implementation": extra_config_param}
                 )
-                self.assertTrue(pytorch_model is not None)
+                self.assertIsNotNone(pytorch_model)
                 self.assertTrue(
                     str(type(list(pytorch_model.operator_map.values())[0])) == gbdt_implementation_map[extra_config_param]
                 )
@@ -42,7 +42,7 @@ class TestLGBMConverter(unittest.TestCase):
             model.fit(X, y)
 
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
     # Binary classifier
@@ -87,7 +87,7 @@ class TestLGBMConverter(unittest.TestCase):
 
             model.fit(X, y)
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
 
     # Regressor

--- a/tests/test_lightgbm_converters.py
+++ b/tests/test_lightgbm_converters.py
@@ -27,8 +27,8 @@ class TestLGBMConverter(unittest.TestCase):
                     model, "pytorch", extra_config={"tree_implementation": extra_config_param}
                 )
                 self.assertIsNotNone(pytorch_model)
-                self.assertTrue(
-                    str(type(list(pytorch_model.operator_map.values())[0])) == gbdt_implementation_map[extra_config_param]
+                self.assertEqual(
+                    str(type(list(pytorch_model.operator_map.values())[0])), gbdt_implementation_map[extra_config_param]
                 )
 
     def _run_lgbm_classifier_converter(self, num_classes, extra_config={}):

--- a/tests/test_sklearn_decision_tree_converters.py
+++ b/tests/test_sklearn_decision_tree_converters.py
@@ -28,7 +28,7 @@ class TestSklearnTreeConverter(unittest.TestCase):
                 pytorch_model = hummingbird.ml.convert(
                     model, "pytorch", extra_config={"tree_implementation": extra_config_param}
                 )
-                self.assertTrue(pytorch_model is not None)
+                self.assertIsNotNone(pytorch_model)
                 self.assertTrue(
                     str(type(list(pytorch_model.operator_map.values())[0])) == dt_implementation_map[extra_config_param]
                 )
@@ -44,7 +44,7 @@ class TestSklearnTreeConverter(unittest.TestCase):
             model = model_type(max_depth=max_depth, **kwargs)
             model.fit(X, y)
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
     # Random forest binary classifier
@@ -102,7 +102,7 @@ class TestSklearnTreeConverter(unittest.TestCase):
 
             model.fit(X, y)
             pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
 
     # Random forest regressor
@@ -169,7 +169,7 @@ class TestSklearnTreeConverter(unittest.TestCase):
         y = np.random.randint(1, size=1)
         model = RandomForestClassifier(n_estimators=1).fit(X, y)
         pytorch_model = hummingbird.ml.convert(model, "pytorch", extra_config=extra_config)
-        self.assertTrue(pytorch_model is not None)
+        self.assertIsNotNone(pytorch_model)
         np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
     # Small tree gemm implementation

--- a/tests/test_xgboost_converters.py
+++ b/tests/test_xgboost_converters.py
@@ -27,8 +27,8 @@ class TestXGBoostConverter(unittest.TestCase):
                     model, "pytorch", X[0:1], extra_config={"tree_implementation": extra_config_param}
                 )
                 self.assertIsNotNone(pytorch_model)
-                self.assertTrue(
-                    str(type(list(pytorch_model.operator_map.values())[0])) == gbdt_implementation_map[extra_config_param]
+                self.assertEqual(
+                    str(type(list(pytorch_model.operator_map.values())[0])), gbdt_implementation_map[extra_config_param]
                 )
 
     def _run_xgb_classifier_converter(self, num_classes, extra_config={}):

--- a/tests/test_xgboost_converters.py
+++ b/tests/test_xgboost_converters.py
@@ -26,7 +26,7 @@ class TestXGBoostConverter(unittest.TestCase):
                 pytorch_model = hummingbird.ml.convert(
                     model, "pytorch", X[0:1], extra_config={"tree_implementation": extra_config_param}
                 )
-                self.assertTrue(pytorch_model is not None)
+                self.assertIsNotNone(pytorch_model)
                 self.assertTrue(
                     str(type(list(pytorch_model.operator_map.values())[0])) == gbdt_implementation_map[extra_config_param]
                 )
@@ -42,7 +42,7 @@ class TestXGBoostConverter(unittest.TestCase):
             model.fit(X, y)
 
             pytorch_model = hummingbird.ml.convert(model, "pytorch", [], extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
     # Binary classifier
@@ -87,7 +87,7 @@ class TestXGBoostConverter(unittest.TestCase):
 
             model.fit(X, y)
             pytorch_model = hummingbird.ml.convert(model, "pytorch", X[0:1], extra_config=extra_config)
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict(X), pytorch_model.predict(X), rtol=1e-06, atol=1e-06)
 
     # Regressor
@@ -120,7 +120,7 @@ class TestXGBoostConverter(unittest.TestCase):
             pytorch_model = hummingbird.ml.convert(
                 model, "pytorch", [], extra_config={"tree_implementation": extra_config_param}
             )
-            self.assertTrue(pytorch_model is not None)
+            self.assertIsNotNone(pytorch_model)
             np.testing.assert_allclose(model.predict_proba(X), pytorch_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
 


### PR DESCRIPTION
Addresses #113 

This CR:
- Changes assert(... is not None) into assertIsNotNone 
- Also, uses isEqual assert where appropriate for readability.

Validations:
- Tests pass locally. No "functional" changes