### PR TITLE
Cleanup Normalizer Converter Code

### DIFF
--- a/doc/html/hummingbird/ml/supported.html
+++ b/doc/html/hummingbird/ml/supported.html
@@ -27,6 +27,7 @@
 <p><strong>Supported Backends</strong>
 PyTorch</p>
 <p><strong>Supported Operators</strong>
+Normalizer,
 DecisionTreeClassifier,
 DecisionTreeRegressor,
 ExtraTreesClassifier,
@@ -58,6 +59,7 @@ All operators, backends, and configurations settings supported in Hummingbird ar
 PyTorch
 
 **Supported Operators**
+Normalizer,
 DecisionTreeClassifier,
 DecisionTreeRegressor,
 ExtraTreesClassifier,
@@ -100,10 +102,14 @@ def _build_sklearn_operator_list():
             RandomForestClassifier,
             RandomForestRegressor,
         )
+
         from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
+        from sklearn.preprocessing import Normalizer
+
         return [
-            # Tree-methods
+            # Return Sklearn models
+            Normalizer,
             DecisionTreeClassifier,
             DecisionTreeRegressor,
             ExtraTreesClassifier,

--- a/hummingbird/ml/operator_converters/__init__.py
+++ b/hummingbird/ml/operator_converters/__init__.py
@@ -21,6 +21,7 @@ from . import gbdt  # noqa: E402
 from . import lightgbm  # noqa: E402
 from . import decision_tree  # noqa: E402
 from . import xgb  # noqa: E402
+from . import normalizer  # noqa: E402
 
 __pdoc__ = {}
 __pdoc__["hummingbird.operator_converters._gbdt_commons"] = True

--- a/hummingbird/ml/operator_converters/normalizer.py
+++ b/hummingbird/ml/operator_converters/normalizer.py
@@ -1,0 +1,31 @@
+# -------------------------------------------------------------------------
+# Copyright (c) Microsoft Corporation. All rights reserved.
+# Licensed under the MIT License. See License.txt in the project root for
+# license information.
+# --------------------------------------------------------------------------
+import torch
+from onnxconverter_common.registration import register_converter
+
+
+class Normalizer(torch.nn.Module):
+    def __init__(self, norm, device):
+        super(Normalizer, self).__init__()
+        self.norm = norm
+        self.regression = False
+
+    def forward(self, x):
+        if self.norm == "l1":
+            return x / torch.abs(x).sum(1, keepdim=True)
+        elif self.norm == "l2":
+            return x / torch.pow(torch.pow(x, 2).sum(1, keepdim=True), 0.5)
+        elif self.norm == "max":
+            return x / torch.max(torch.abs(x), dim=1, keepdim=True)[0]
+        else:
+            raise RuntimeError("Unsupported norm: {0}".format(self.norm))
+
+
+def convert_sklearn_normalizer(operator, device, extra_config):
+    return Normalizer(operator.raw_operator.norm, device)
+
+
+register_converter("SklearnNormalizer", convert_sklearn_normalizer)

--- a/hummingbird/ml/supported.py
+++ b/hummingbird/ml/supported.py
@@ -37,7 +37,7 @@ def _build_sklearn_operator_list():
     Put all suported Sklearn operators on a list.
     """
     if sklearn_installed():
-        # Enable experimental to import HistGradientBoostingClassifier
+        # Enable experimental to import HistGradientBoosting*
         from sklearn.experimental import enable_hist_gradient_boosting
 
         # Tree-based models

--- a/hummingbird/ml/supported.py
+++ b/hummingbird/ml/supported.py
@@ -11,6 +11,7 @@ All operators, backends, and configurations settings supported in Hummingbird ar
 PyTorch
 
 **Supported Operators**
+Normalizer,
 DecisionTreeClassifier,
 DecisionTreeRegressor,
 ExtraTreesClassifier,
@@ -36,7 +37,7 @@ def _build_sklearn_operator_list():
     Put all suported Sklearn operators on a list.
     """
     if sklearn_installed():
-        # Enable experimental to import HistGradientBoostingClassifier and HistGradientBoostingRegressor
+        # Enable experimental to import HistGradientBoostingClassifier
         from sklearn.experimental import enable_hist_gradient_boosting
 
         # Tree-based models
@@ -50,10 +51,14 @@ def _build_sklearn_operator_list():
             RandomForestClassifier,
             RandomForestRegressor,
         )
+
         from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
+        from sklearn.preprocessing import Normalizer
+
         return [
-            # Tree-methods
+            # Return Sklearn models
+            Normalizer,
             DecisionTreeClassifier,
             DecisionTreeRegressor,
             ExtraTreesClassifier,

--- a/tests/test_sklearn_normalizer_converter.py
+++ b/tests/test_sklearn_normalizer_converter.py
@@ -2,6 +2,7 @@
 Tests sklearn Normalizer converter
 """
 import unittest
+import warnings
 
 import numpy as np
 import torch
@@ -12,7 +13,10 @@ import hummingbird.ml
 
 class TestSklearnNormalizer(unittest.TestCase):
     def test_normalizer_converter(self):
-        data = np.array([[1, 2, 3], [4, 3, 0], [0, 1, 4], [0, 5, 6]], dtype=np.float32)
+        # Generate a random 2D array with values in [0, 1000)
+        np.random.seed(0)
+        data = np.random.rand(100, 200) * 1000
+        data = np.array(data, dtype=np.float32)
         data_tensor = torch.from_numpy(data)
 
         for norm in ["l1", "l2", "max"]:
@@ -22,7 +26,25 @@ class TestSklearnNormalizer(unittest.TestCase):
             pytorch_model = hummingbird.ml.convert(model, "pytorch")
 
             self.assertIsNotNone(pytorch_model)
-            np.testing.assert_allclose(model.transform(data), pytorch_model.operator_map.SklearnNormalizer(data_tensor))
+            np.testing.assert_allclose(
+                model.transform(data),
+                pytorch_model.operator_map.SklearnNormalizer(data_tensor).cpu().numpy(),
+                rtol=1e-06,
+                atol=1e-06,
+            )
+
+    def test_normalizer_converter_raises_wrong_type(self):
+        # Generate a random 2D array with values in [0, 1000)
+        np.random.seed(0)
+        data = np.random.rand(100, 200) * 1000
+        data = np.array(data, dtype=np.float32)
+
+        model = Normalizer(norm="invalid")
+        model.fit(data)
+
+        pytorch_model = hummingbird.ml.convert(model, "pytorch")
+
+        self.assertRaises(RuntimeError, pytorch_model.operator_map.SklearnNormalizer, torch.from_numpy(data))
 
 
 if __name__ == "__main__":

--- a/tests/test_sklearn_normalizer_converter.py
+++ b/tests/test_sklearn_normalizer_converter.py
@@ -1,0 +1,29 @@
+"""
+Tests sklearn Normalizer converter
+"""
+import unittest
+
+import numpy as np
+import torch
+from sklearn.preprocessing import Normalizer
+
+import hummingbird.ml
+
+
+class TestSklearnNormalizer(unittest.TestCase):
+    def test_normalizer_converter(self):
+        data = np.array([[1, 2, 3], [4, 3, 0], [0, 1, 4], [0, 5, 6]], dtype=np.float32)
+        data_tensor = torch.from_numpy(data)
+
+        for norm in ["l1", "l2", "max"]:
+            model = Normalizer(norm=norm)
+            model.fit(data)
+
+            pytorch_model = hummingbird.ml.convert(model, "pytorch")
+
+            self.assertIsNotNone(pytorch_model)
+            np.testing.assert_allclose(model.transform(data), pytorch_model.operator_map.SklearnNormalizer(data_tensor))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #126 

This PR cleans up the implementation of the [sklearn.preprocessing.Normalizer](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.Normalizer.html) as well as its test file from the [cleanup/normalizer](https://github.com/microsoft/hummingbird/tree/cleanup/normalizer) branch.