### PR TITLE
Update LGBM-example.ipynb

### DIFF
--- a/notebooks/LGBM-example.ipynb
+++ b/notebooks/LGBM-example.ipynb
@@ -2,8 +2,9 @@
  "cells": [
   {
       "cell_type": "code",
+      "metadata": {},
       "source": [
-        "!pip install hummingbird_ml"
+        "!pip install hummingbird_ml[extra]"
       ],
       "execution_count": null,
       "outputs": []

--- a/notebooks/LGBM-example.ipynb
+++ b/notebooks/LGBM-example.ipynb
@@ -1,6 +1,14 @@
 {
  "cells": [
   {
+      "cell_type": "code",
+      "source": [
+        "!pip install hummingbird_ml"
+      ],
+      "execution_count": null,
+      "outputs": []
+    },
+  {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},


### PR DESCRIPTION
Update to add !pip install at the beginning of the NB. This will reduce the tracebacks seen by colab users.