### PR TITLE
Fix to win installation

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Install basic dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install .[tests]
+        pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
     - name: Run basic tests without extra
       run: |
         pytest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,7 @@ cd hummingbird
 git clone https://github.com/microsoft/hummingbird.git .
 pip install -e .[docs,tests,extra]
 ```
+On Windows, the last line above must also contain `-f https://download.pytorch.org/whl/torch_stable.html`. (This is required because PyTorch version for Windows is not up to date.)
 
 ### Docker
 We provide a simple [Dockerfile](https://github.com/microsoft/hummingbird/blob/master/Dockerfile) that you can customize to your preferred development environment.

--- a/README.md
+++ b/README.md
@@ -17,9 +17,14 @@ Currently, you can use *Hummingbird* to convert your trained traditional ML mode
 Hummingbird was tested on Python >= 3.5 on Linux, Windows and MacOS machines.  It is recommended to use a virtual environment (See: [python3 venv doc](https://docs.python.org/3/tutorial/venv.html) or [Using Python environments in VS Code](https://code.visualstudio.com/docs/python/environments).)
 
 
-Install the Hummingbird package:
+Install the Hummingbird package in Linux or Mac
 ```
 pip install hummingbird-ml
+```
+
+To install the package in Windows instead:
+```
+pip install hummingbird-ml -f https://download.pytorch.org/whl/torch_stable.html
 ```
 
 If you require the optional dependencies lightgbm and xgboost, you can use:

--- a/hummingbird/ml/convert.py
+++ b/hummingbird/ml/convert.py
@@ -187,10 +187,10 @@ def _convert_onnxml(model, test_input=None, extra_config={}):
         A model containing only *ONNX* operators. The mode is equivalent to the input *ONNX-ML* model
     """
     assert model is not None
-    assert torch_installed(), "To use Hummingbird you need to install torch."
     assert (
         onnx_runtime_installed()
     ), "To use the onnxml converter you need to install onnxruntime (or `pip install hummingbird-ml[onnx]`)."
+    assert torch_installed(), "To use Hummingbird you need to install torch."
 
     output_model_name = initial_types = input_names = output_names = None
     target_opset = 9

--- a/hummingbird/ml/convert.py
+++ b/hummingbird/ml/convert.py
@@ -187,10 +187,10 @@ def _convert_onnxml(model, test_input=None, extra_config={}):
         A model containing only *ONNX* operators. The mode is equivalent to the input *ONNX-ML* model
     """
     assert model is not None
+    assert torch_installed(), "To use Hummingbird you need to install torch."
     assert (
         onnx_runtime_installed()
     ), "To use the onnxml converter you need to install onnxruntime (or `pip install hummingbird-ml[onnx]`)."
-    assert torch_installed(), "To use Hummingbird you need to install torch."
 
     output_model_name = initial_types = input_names = output_names = None
     target_opset = 9

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ with open(README) as f:
 
 install_requires = ["numpy>=1.15", "onnxconverter-common>=1.6.0", "scikit-learn==0.22.1"]
 if sys.platform == "darwin" or sys.platform == "linux":
-    install_requires.append("torch==1.5.1")
+    install_requires.append("torch==1.4.0")
 else:
-    install_requires.append("torch==1.5.1+cpu")
+    install_requires.append("torch==1.4.0+cpu")
 setup(
     name="hummingbird-ml",
     version=version_str,

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,9 @@ with open(README) as f:
 
 install_requires = ["numpy>=1.15", "onnxconverter-common>=1.6.0", "scikit-learn==0.22.1"]
 if sys.platform == "darwin" or sys.platform == "linux":
-    install_requires.append("torch==1.4.0")
+    install_requires.append("torch==1.5.1")
 else:
-    install_requires.append("torch==1.4.0+cpu")
+    install_requires.append("torch==1.5.1+cpu")
 setup(
     name="hummingbird-ml",
     version=version_str,

--- a/setup.py
+++ b/setup.py
@@ -23,18 +23,9 @@ with open(README) as f:
 
 install_requires = ["numpy>=1.15", "onnxconverter-common>=1.6.0", "scikit-learn==0.22.1"]
 if sys.platform == "darwin" or sys.platform == "linux":
-    install_requires.append("torch>=1.4.0")
+    install_requires.append("torch==1.4.0")
 else:
-    if sys.version_info[:2] == (3, 8):
-        install_requires.append("torch @ https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp38-cp38-win_amd64.whl")
-    elif sys.version_info[:2] == (3, 7):
-        install_requires.append("torch @ https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp37-cp37m-win_amd64.whl")
-    elif sys.version_info[:2] == (3, 6):
-        install_requires.append("torch @ https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp36-cp36m-win_amd64.whl")
-    elif sys.version_info[:2] == (3, 5):
-        install_requires.append("torch @ https://download.pytorch.org/whl/cpu/torch-1.5.0%2Bcpu-cp35-cp35m-win_amd64.whl")
-    else:
-        raise Exception("Python version < 3.5 not supported.")
+    install_requires.append("torch==1.4.0+cpu")
 setup(
     name="hummingbird-ml",
     version=version_str,


### PR DESCRIPTION
Closes #166.

This PR 
- pins the version for PyTorch to 1.4.0 (version >=1.5.0 introduce 10X performance regression)
- fix installation for Windows