### PR TITLE
Improving lightgbm ONNX backend example : Reduce sample size to make nb usable

### DIFF
--- a/notebooks/LGBM-ONNX-example.ipynb
+++ b/notebooks/LGBM-ONNX-example.ipynb
@@ -115,7 +115,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "2.61 s ± 43.8 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)\n"
+      "2.82 s ± 33.3 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)\n"
      ]
     }
    ],

--- a/notebooks/LGBM-ONNX-example.ipynb
+++ b/notebooks/LGBM-ONNX-example.ipynb
@@ -2,6 +2,15 @@
  "cells": [
   {
    "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip install hummingbird_ml[extra,onnx]"
+   ]
+  },
+  {
+   "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
    "outputs": [],
@@ -19,8 +28,8 @@
     "\n",
     "# Create some random data for binary classification.\n",
     "num_classes = 2\n",
-    "X = np.array(np.random.rand(200000, 28), dtype=np.float32)\n",
-    "y = np.random.randint(num_classes, size=200000)"
+    "X = np.array(np.random.rand(10000, 28), dtype=np.float32)\n",
+    "y = np.random.randint(num_classes, size=10000)"
    ]
   },
   {
@@ -29,12 +38,19 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "execute_result",
      "data": {
-      "text/plain": "LGBMClassifier(boosting_type='gbdt', class_weight=None, colsample_bytree=1.0,\n               importance_type='split', learning_rate=0.1, max_depth=-1,\n               min_child_samples=20, min_child_weight=0.001, min_split_gain=0.0,\n               n_estimators=100, n_jobs=-1, num_leaves=31, objective=None,\n               random_state=None, reg_alpha=0.0, reg_lambda=0.0, silent=True,\n               subsample=1.0, subsample_for_bin=200000, subsample_freq=0)"
+      "text/plain": [
+       "LGBMClassifier(boosting_type='gbdt', class_weight=None, colsample_bytree=1.0,\n",
+       "               importance_type='split', learning_rate=0.1, max_depth=-1,\n",
+       "               min_child_samples=20, min_child_weight=0.001, min_split_gain=0.0,\n",
+       "               n_estimators=100, n_jobs=-1, num_leaves=31, objective=None,\n",
+       "               random_state=None, reg_alpha=0.0, reg_lambda=0.0, silent=True,\n",
+       "               subsample=1.0, subsample_for_bin=200000, subsample_freq=0)"
+      ]
      },
+     "execution_count": 2,
      "metadata": {},
-     "execution_count": 2
+     "output_type": "execute_result"
     }
    ],
    "source": [
@@ -47,18 +63,12 @@
    "cell_type": "code",
    "execution_count": 3,
    "metadata": {},
-   "outputs": [
-    {
-     "output_type": "stream",
-     "name": "stderr",
-     "text": "The maximum opset needed by this model is only 1.\nThe maximum opset needed by this model is only 1.\n"
-    }
-   ],
+   "outputs": [],
    "source": [
     "# Use ONNXMLTOOLS to convert the model to ONNXML.\n",
-    "innitial_types = [(\"input\", FloatTensorType([X.shape[0], X.shape[1]]))] # Define the inputs for the ONNX\n",
+    "initial_types = [(\"input\", FloatTensorType([X.shape[0], X.shape[1]]))] # Define the inputs for the ONNX\n",
     "onnx_ml_model = convert_lightgbm(\n",
-    "    model, initial_types=innitial_types, target_opset=9\n",
+    "    model, initial_types=initial_types, target_opset=9\n",
     ")"
    ]
   },
@@ -80,7 +90,7 @@
    "source": [
     "# Alternatively we can set the inital types using the extra_config parameters as in the ONNXMLTOOL converter.\n",
     "extra_config = {}\n",
-    "extra_config[constants.ONNX_INITIAL_TYPES] = input_types\n",
+    "extra_config[constants.ONNX_INITIAL_TYPES] = initial_types\n",
     "onnx_model = convert(onnx_ml_model, \"onnx\", extra_config=extra_config)"
    ]
   },
@@ -102,9 +112,11 @@
    "metadata": {},
    "outputs": [
     {
-     "output_type": "stream",
      "name": "stdout",
-     "text": "2min 14s ± 12.4 s per loop (mean ± std. dev. of 3 runs, 1 loop each)\n"
+     "output_type": "stream",
+     "text": [
+      "2.61 s ± 43.8 ms per loop (mean ± std. dev. of 3 runs, 1 loop each)\n"
+     ]
     }
    ],
    "source": [
@@ -113,13 +125,6 @@
     "# Run the ONNX model on CPU \n",
     "session.run(output_names, inputs)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -138,7 +143,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8-final"
+   "version": "3.7.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #207 

- Add handy 'pip install' commands cell similar to other notebooks (for improving experience in Google Colab)
- Fix typos in some of the cells (innitial_types vs input_types) so the users can execute the example.
- Reducing the number of samples for the moment to make the notebook usable.
