### PR TITLE
Error when convert XGBClassifier to onnx

### DIFF
--- a/hummingbird/ml/operator_converters/onnx/onnxml_tree_ensemble.py
+++ b/hummingbird/ml/operator_converters/onnx/onnxml_tree_ensemble.py
@@ -58,7 +58,7 @@ def _get_tree_infos_from_onnx_ml_operator(model):
         elif attr.name == "nodes_modes":
             modes = attr.strings
             for mode in modes:
-                if (not mode == b"BRANCH_LEQ") and (not mode == b"LEAF"):
+                if (not mode == b"BRANCH_LEQ") and (not mode == b"LEAF") and (not mode == b"BRANCH_LT"):
                     raise AssertionError("Modality {} not supported".format(mode))
 
     is_decision_tree = post_transform == "NONE"


### PR DESCRIPTION
When I convert XGBClassifier to onnx an error appears: "AssertionError: Modality b'BRANCH_LT' not supported"

```import numpy as np
import xgboost as xgb
from hummingbird.ml import convert
from sklearn.metrics import accuracy_score
from onnxconverter_common.data_types import FloatTensorType
from onnxmltools.convert import convert_xgboost
import onnxruntime as ort

num_classes = 2
X = np.array(np.random.rand(10000, 28), dtype=np.float32)
y = np.random.randint(num_classes, size=10000)
X_test = np.array(np.random.rand(10000, 28), dtype=np.float32)
y_test = np.random.randint(num_classes, size=10000)

model = xgb.XGBClassifier()
model.fit(X, y)

predict = model.predict(X_test)
print('accuracy', accuracy_score(y_test, predict))


initial_types = [("input", FloatTensorType([X.shape[0], X.shape[1]]))] # Define the inputs for the ONNX
onnx_ml_model = convert_xgboost(model, initial_types=initial_types, target_opset=9)

onnx_model = convert(onnx_ml_model, "onnx", X)

session = ort.InferenceSession(onnx_model.SerializeToString())
output_names = [session.get_outputs()[i].name for i in range(len(session.get_outputs()))]
inputs = {session.get_inputs()[0].name: X_test}

predict_2 = session.run(output_names, inputs)[0]
print('accuracy after', accuracy_score(y_test, predict_2))
