### PR TITLE
Issue #254 - LogisticRegression returns wrong results with lbfgs

### DIFF
--- a/doc/html/hummingbird/ml/operator_converters/sklearn/linear.html
+++ b/doc/html/hummingbird/ml/operator_converters/sklearn/linear.html
@@ -26,7 +26,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L0-L73" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L0-L75" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python"># -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -71,6 +71,8 @@ def convert_sklearn_linear_model(operator, device, extra_config):
     multi_class = None
     if hasattr(operator.raw_operator, &#34;multi_class&#34;):
         if operator.raw_operator.multi_class == &#34;ovr&#34; or operator.raw_operator.solver in [&#34;warn&#34;, &#34;liblinear&#34;]:
+            multi_class = &#34;ovr&#34;
+        elif operator.raw_operator.multi_class == &#34;auto&#34; and len(classes) == 2:
             multi_class = &#34;ovr&#34;
         else:
             multi_class = &#34;multinomial&#34;
@@ -135,7 +137,7 @@ register_converter(&#34;SklearnLogisticRegressionCV&#34;, convert_sklearn_linear
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L17-L48" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L17-L50" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def convert_sklearn_linear_model(operator, device, extra_config):
     &#34;&#34;&#34;
@@ -165,6 +167,8 @@ register_converter(&#34;SklearnLogisticRegressionCV&#34;, convert_sklearn_linear
     if hasattr(operator.raw_operator, &#34;multi_class&#34;):
         if operator.raw_operator.multi_class == &#34;ovr&#34; or operator.raw_operator.solver in [&#34;warn&#34;, &#34;liblinear&#34;]:
             multi_class = &#34;ovr&#34;
+        elif operator.raw_operator.multi_class == &#34;auto&#34; and len(classes) == 2:
+            multi_class = &#34;ovr&#34;
         else:
             multi_class = &#34;multinomial&#34;
 
@@ -193,7 +197,7 @@ register_converter(&#34;SklearnLogisticRegressionCV&#34;, convert_sklearn_linear
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L51-L67" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/linear.py#L53-L69" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def convert_sklearn_linear_regression_model(operator, device, extra_config):
     &#34;&#34;&#34;

--- a/hummingbird/ml/operator_converters/sklearn/linear.py
+++ b/hummingbird/ml/operator_converters/sklearn/linear.py
@@ -42,6 +42,8 @@ def convert_sklearn_linear_model(operator, device, extra_config):
     if hasattr(operator.raw_operator, "multi_class"):
         if operator.raw_operator.multi_class == "ovr" or operator.raw_operator.solver in ["warn", "liblinear"]:
             multi_class = "ovr"
+        elif operator.raw_operator.multi_class == "auto" and len(classes) == 2:
+            multi_class = "ovr"
         else:
             multi_class = "multinomial"
 

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -48,11 +48,35 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
     def test_logistic_regression_multi_ovr(self):
         self._test_logistic_regression(3, multi_class="ovr")
 
-    # LogisticRegression with multi+multinomial
-    def test_logistic_regression_multi_multin(self):
+    # LogisticRegression with multi+multinomial+sag
+    def test_logistic_regression_multi_multin_sag(self):
         warnings.filterwarnings("ignore")
         # this will not converge due to small test size
         self._test_logistic_regression(3, multi_class="multinomial", solver="sag")
+
+    # LogisticRegression binary lbfgs
+    def test_logistic_regression_bi_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(2, solver="lbfgs")
+
+    # LogisticRegression with multi+lbfgs
+    def test_logistic_regression_multi_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, solver="lbfgs")
+
+    # LogisticRegression with multi+multinomial+lbfgs
+    def test_logistic_regression_multi_multin_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, multi_class="multinomial", solver="lbfgs")
+
+    # LogisticRegression with multi+ovr+lbfgs
+    def test_logistic_regression_multi_ovr_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, multi_class="ovr", solver="lbfgs")
 
     # LinearRegression test function to be parameterized
     def _test_linear_regression(self, y_input):


### PR DESCRIPTION
This pull request fixes the issue in Logistic Regression with auto multiclass option and binary data.
Quoting the corresponding section from sklearn documentation:

multi_class{‘auto’, ‘ovr’, ‘multinomial’}, default=’auto’
If the option chosen is ‘ovr’, then a binary problem is fit for each label. For ‘multinomial’ the loss minimised is the multinomial loss fit across the entire probability distribution, even when the data is binary. ‘multinomial’ is unavailable when solver=’liblinear’. ‘auto’ selects ‘ovr’ if the data is binary, or if solver=’liblinear’, and otherwise selects ‘multinomial’.

Testing:
- Extended the existing LogisticRegression test file to include test cases with multiclass option set to auto and binary classification.
