### PR TITLE
TS container for classification calls the wrong predict method

### DIFF
--- a/hummingbird/ml/_container.py
+++ b/hummingbird/ml/_container.py
@@ -248,7 +248,7 @@ def _torchscript_wrapper(device, function, *inputs):
                 inputs[i] = torch.from_numpy(inputs[i]).float()
             elif type(inputs[i]) is not torch.Tensor:
                 raise RuntimeError("Inputer tensor {} of not supported type {}".format(i, type(inputs[i])))
-            if device is not None:
+            if device != "cpu" and device is not None:
                 inputs[i] = inputs[i].to(device)
         return function(*inputs)
 
@@ -277,10 +277,14 @@ class TorchScriptSklearnContainerRegression(PyTorchSklearnContainerRegression):
         return _torchscript_wrapper(device, f, *inputs)
 
 
-class TorchScriptSklearnContainerClassification(PyTorchSklearnContainerClassification):
+class TorchScriptSklearnContainerClassification(TorchScriptSklearnContainerRegression, PyTorchSklearnContainerClassification):
     """
     Container mirroring Sklearn classifiers API.
     """
+
+    def __init__(self, model, extra_config={}):
+        TorchScriptSklearnContainerRegression.__init__(self, model, extra_config, is_regression=False)
+        PyTorchSklearnContainerClassification.__init__(self, model, extra_config)
 
     def predict_proba(self, *inputs):
         device = _get_device(self.model)

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -7,6 +7,7 @@ import warnings
 import numpy as np
 import torch
 from sklearn.linear_model import LinearRegression, LogisticRegression, SGDClassifier, LogisticRegressionCV
+from sklearn import datasets
 
 import hummingbird.ml
 
@@ -206,6 +207,22 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
         torch_model = hummingbird.ml.convert(model, "torch")
         self.assertTrue(torch_model is not None)
         np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # Test Torschscript backend.
+    def test_logistic_regression_ts(self):
+
+        model = LogisticRegression(solver="liblinear")
+
+        data = datasets.load_iris()
+        X, y = data.data, data.target
+        X = X.astype(np.float32)
+
+        model.fit(X, y)
+
+        ts_model = hummingbird.ml.convert(model, "torch.jit", X)
+        self.assertTrue(ts_model is not None)
+        np.testing.assert_allclose(model.predict(X), ts_model.predict(X), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(model.predict_proba(X), ts_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
There is a bug in the TS container for classification. The class inheritance is wrong the when `predict` is called it is actually run the `predict` method in the Pytorch container.