### PR TITLE
fix isolation forest for sklearn <= 0.21

### DIFF
--- a/doc/html/hummingbird/ml/operator_converters/constants.html
+++ b/doc/html/hummingbird/ml/operator_converters/constants.html
@@ -26,7 +26,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/constants.py#L0-L50" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/constants.py#L0-L53" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python"># -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -77,6 +77,9 @@ NUM_TREES = &#34;n_trees&#34;
 OFFSET = &#34;offset&#34;
 &#34;&#34;&#34;offset of the sklearn anomaly detection implementation&#34;&#34;&#34;
 
+IFOREST_THRESHOLD = &#34;iforest_threshold&#34;
+&#34;&#34;&#34;threshold of the sklearn isolation forest implementation, backward compatibility for sklearn &lt;= 0.21&#34;&#34;&#34;
+
 MAX_SAMPLES = &#34;max_samples&#34;
 &#34;&#34;&#34;max_samples of sklearn isolation forest implementation&#34;&#34;&#34;</code></pre>
 </details>
@@ -93,6 +96,10 @@ MAX_SAMPLES = &#34;max_samples&#34;
 <dt id="hummingbird.ml.operator_converters.constants.GET_PARAMETERS_FOR_TREE_TRAVERSAL"><code class="name">var <span class="ident">GET_PARAMETERS_FOR_TREE_TRAVERSAL</span></code></dt>
 <dd>
 <div class="desc"><p>Which function to use to extract the parameters for the tree traversal strategy</p></div>
+</dd>
+<dt id="hummingbird.ml.operator_converters.constants.IFOREST_THRESHOLD"><code class="name">var <span class="ident">IFOREST_THRESHOLD</span></code></dt>
+<dd>
+<div class="desc"><p>threshold of the sklearn isolation forest implementation, backward compatibility for sklearn &lt;= 0.21</p></div>
 </dd>
 <dt id="hummingbird.ml.operator_converters.constants.LEARNING_RATE"><code class="name">var <span class="ident">LEARNING_RATE</span></code></dt>
 <dd>
@@ -168,6 +175,7 @@ MAX_SAMPLES = &#34;max_samples&#34;
 <ul class="">
 <li><code><a title="hummingbird.ml.operator_converters.constants.BASE_PREDICTION" href="#hummingbird.ml.operator_converters.constants.BASE_PREDICTION">BASE_PREDICTION</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.constants.GET_PARAMETERS_FOR_TREE_TRAVERSAL" href="#hummingbird.ml.operator_converters.constants.GET_PARAMETERS_FOR_TREE_TRAVERSAL">GET_PARAMETERS_FOR_TREE_TRAVERSAL</a></code></li>
+<li><code><a title="hummingbird.ml.operator_converters.constants.IFOREST_THRESHOLD" href="#hummingbird.ml.operator_converters.constants.IFOREST_THRESHOLD">IFOREST_THRESHOLD</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.constants.LEARNING_RATE" href="#hummingbird.ml.operator_converters.constants.LEARNING_RATE">LEARNING_RATE</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.constants.MAX_SAMPLES" href="#hummingbird.ml.operator_converters.constants.MAX_SAMPLES">MAX_SAMPLES</a></code></li>
 <li><code><a title="hummingbird.ml.operator_converters.constants.NUM_TREES" href="#hummingbird.ml.operator_converters.constants.NUM_TREES">NUM_TREES</a></code></li>

--- a/doc/html/hummingbird/ml/operator_converters/sklearn/iforest.html
+++ b/doc/html/hummingbird/ml/operator_converters/sklearn/iforest.html
@@ -26,7 +26,7 @@
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L0-L250" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L0-L262" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python"># -------------------------------------------------------------------------
 # Copyright (c) Microsoft Corporation. All rights reserved.
@@ -143,6 +143,9 @@ class GEMMIsolationForestImpl(GEMMTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -151,7 +154,7 @@ class GEMMIsolationForestImpl(GEMMTreeImpl):
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output
 
 
@@ -178,6 +181,9 @@ class TreeTraversalIsolationForestImpl(TreeTraversalTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -186,7 +192,7 @@ class TreeTraversalIsolationForestImpl(TreeTraversalTreeImpl):
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output
 
 
@@ -213,6 +219,9 @@ class PerfectTreeTraversalIsolationForestImpl(PerfectTreeTraversalTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -221,7 +230,7 @@ class PerfectTreeTraversalIsolationForestImpl(PerfectTreeTraversalTreeImpl):
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output
 
 
@@ -244,6 +253,9 @@ def convert_sklearn_isolation_forest(operator, device, extra_config):
     n_features = operator.raw_operator.n_features_
     # Following constants will be passed in the tree implementation to normalize the anomaly score.
     extra_config[constants.OFFSET] = operator.raw_operator.offset_
+    extra_config[constants.IFOREST_THRESHOLD] = (
+        operator.raw_operator.threshold_ if hasattr(operator.raw_operator, &#34;threshold_&#34;) else 0
+    )
     extra_config[constants.MAX_SAMPLES] = operator.raw_operator.max_samples_
 
     # Predict in isolation forest sklearn implementation produce 2 classes: -1 (normal) &amp; 1 (anomaly).
@@ -310,7 +322,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L198-L247" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L207-L259" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def convert_sklearn_isolation_forest(operator, device, extra_config):
     &#34;&#34;&#34;
@@ -331,6 +343,9 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
     n_features = operator.raw_operator.n_features_
     # Following constants will be passed in the tree implementation to normalize the anomaly score.
     extra_config[constants.OFFSET] = operator.raw_operator.offset_
+    extra_config[constants.IFOREST_THRESHOLD] = (
+        operator.raw_operator.threshold_ if hasattr(operator.raw_operator, &#34;threshold_&#34;) else 0
+    )
     extra_config[constants.MAX_SAMPLES] = operator.raw_operator.max_samples_
 
     # Predict in isolation forest sklearn implementation produce 2 classes: -1 (normal) &amp; 1 (anomaly).
@@ -389,7 +404,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L96-L125" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L96-L128" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class GEMMIsolationForestImpl(GEMMTreeImpl):
     &#34;&#34;&#34;
@@ -411,6 +426,9 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -419,7 +437,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -451,14 +469,14 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L119-L125" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L122-L128" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def aggregation(self, x):
     output = x.sum(0).t()
     if self.final_probability_divider &gt; 1:
         output = output / self.final_probability_divider
     # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
     return output</code></pre>
 </details>
 </dd>
@@ -486,7 +504,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L163-L195" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L169-L204" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class PerfectTreeTraversalIsolationForestImpl(PerfectTreeTraversalTreeImpl):
     &#34;&#34;&#34;
@@ -511,6 +529,9 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -519,7 +540,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -551,14 +572,14 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L189-L195" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L198-L204" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def aggregation(self, x):
     output = x.sum(1)
     if self.final_probability_divider &gt; 1:
         output = output / self.final_probability_divider
     # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
     return output</code></pre>
 </details>
 </dd>
@@ -586,7 +607,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L128-L160" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L131-L166" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">class TreeTraversalIsolationForestImpl(TreeTraversalTreeImpl):
     &#34;&#34;&#34;
@@ -611,6 +632,9 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
+        # backward compatibility for sklearn &lt;= 0.21
+        if constants.IFOREST_THRESHOLD in extra_config:
+            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -619,7 +643,7 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
         if self.final_probability_divider &gt; 1:
             output = output / self.final_probability_divider
         # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
         return output</code></pre>
 </details>
 <h3>Ancestors</h3>
@@ -651,14 +675,14 @@ register_converter(&#34;SklearnIsolationForest&#34;, convert_sklearn_isolation_f
 <details class="source">
 <summary>
 <span>Expand source code</span>
-<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L154-L160" class="git-link">Browse git</a>
+<a href="https://github.com/microsoft/hummingbird/blob/master/hummingbird/ml/operator_converters/sklearn/iforest.py#L160-L166" class="git-link">Browse git</a>
 </summary>
 <pre><code class="python">def aggregation(self, x):
     output = x.sum(1)
     if self.final_probability_divider &gt; 1:
         output = output / self.final_probability_divider
     # Further normalize to match &#34;decision_function&#34; in sklearn implementation.
-    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
+    output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
     return output</code></pre>
 </details>
 </dd>

--- a/hummingbird/ml/_container.py
+++ b/hummingbird/ml/_container.py
@@ -224,7 +224,7 @@ class PyTorchSklearnContainerAnomalyDetection(PyTorchSklearnContainerRegression)
         On anomaly detection (e.g. isolation forest) returns the decision function scores.
         """
         scores = self.model.forward(*inputs)[1].cpu().numpy().flatten()
-        # backward compatibility for sklearn <= 0.21
+        # Backward compatibility for sklearn <= 0.21
         if constants.IFOREST_THRESHOLD in self._extra_config:
             scores += self._extra_config[constants.IFOREST_THRESHOLD]
         return scores
@@ -458,7 +458,11 @@ class ONNXSklearnContainerAnomalyDetection(ONNXSklearnContainerRegression):
         """
         named_inputs = self._get_named_inputs(inputs)
 
-        return np.array(self._session.run([self._output_names[1]], named_inputs)[0]).flatten()
+        scores = np.array(self._session.run([self._output_names[1]], named_inputs)[0]).flatten()
+        # Backward compatibility for sklearn <= 0.21
+        if constants.IFOREST_THRESHOLD in self._extra_config:
+            scores += self._extra_config[constants.IFOREST_THRESHOLD]
+        return scores
 
     def score_samples(self, *inputs):
         """

--- a/hummingbird/ml/_container.py
+++ b/hummingbird/ml/_container.py
@@ -223,7 +223,11 @@ class PyTorchSklearnContainerAnomalyDetection(PyTorchSklearnContainerRegression)
         Utility functions used to emulate the behavior of the Sklearn API.
         On anomaly detection (e.g. isolation forest) returns the decision function scores.
         """
-        return self.model.forward(*inputs)[1].cpu().numpy().flatten()
+        scores = self.model.forward(*inputs)[1].cpu().numpy().flatten()
+        # backward compatibility for sklearn <= 0.21
+        if constants.IFOREST_THRESHOLD in self._extra_config:
+            scores += self._extra_config[constants.IFOREST_THRESHOLD]
+        return scores
 
     def score_samples(self, *inputs):
         """

--- a/hummingbird/ml/operator_converters/constants.py
+++ b/hummingbird/ml/operator_converters/constants.py
@@ -47,5 +47,8 @@ NUM_TREES = "n_trees"
 OFFSET = "offset"
 """offset of the sklearn anomaly detection implementation"""
 
+IFOREST_THRESHOLD = "iforest_threshold"
+"""threshold of the sklearn isolation forest implementation, backward compatibility for sklearn <= 0.21"""
+
 MAX_SAMPLES = "max_samples"
 """max_samples of sklearn isolation forest implementation"""

--- a/hummingbird/ml/operator_converters/sklearn/iforest.py
+++ b/hummingbird/ml/operator_converters/sklearn/iforest.py
@@ -113,9 +113,9 @@ class GEMMIsolationForestImpl(GEMMTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
-        # backward compatibility for sklearn <= 0.21
+        # Backward compatibility for sklearn <= 0.21
         if constants.IFOREST_THRESHOLD in extra_config:
-            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
+            self.offset += extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -124,7 +124,7 @@ class GEMMIsolationForestImpl(GEMMTreeImpl):
         if self.final_probability_divider > 1:
             output = output / self.final_probability_divider
         # Further normalize to match "decision_function" in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
         return output
 
 
@@ -151,9 +151,9 @@ class TreeTraversalIsolationForestImpl(TreeTraversalTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
-        # backward compatibility for sklearn <= 0.21
+        # Backward compatibility for sklearn <= 0.21
         if constants.IFOREST_THRESHOLD in extra_config:
-            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
+            self.offset += extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -162,7 +162,7 @@ class TreeTraversalIsolationForestImpl(TreeTraversalTreeImpl):
         if self.final_probability_divider > 1:
             output = output / self.final_probability_divider
         # Further normalize to match "decision_function" in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
         return output
 
 
@@ -189,9 +189,9 @@ class PerfectTreeTraversalIsolationForestImpl(PerfectTreeTraversalTreeImpl):
             self.offset = extra_config[constants.OFFSET]
         if constants.MAX_SAMPLES in extra_config:
             self.max_samples = extra_config[constants.MAX_SAMPLES]
-        # backward compatibility for sklearn <= 0.21
+        # Backward compatibility for sklearn <= 0.21
         if constants.IFOREST_THRESHOLD in extra_config:
-            self.threshold = extra_config[constants.IFOREST_THRESHOLD]
+            self.offset += extra_config[constants.IFOREST_THRESHOLD]
         self.final_probability_divider = len(tree_parameters)
         self.average_path_length = _average_path_length(np.array([self.max_samples]))[0]
 
@@ -200,7 +200,7 @@ class PerfectTreeTraversalIsolationForestImpl(PerfectTreeTraversalTreeImpl):
         if self.final_probability_divider > 1:
             output = output / self.final_probability_divider
         # Further normalize to match "decision_function" in sklearn implementation.
-        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset - self.threshold
+        output = -1.0 * 2 ** (-output / self.average_path_length) - self.offset
         return output
 
 
@@ -223,9 +223,8 @@ def convert_sklearn_isolation_forest(operator, device, extra_config):
     n_features = operator.raw_operator.n_features_
     # Following constants will be passed in the tree implementation to normalize the anomaly score.
     extra_config[constants.OFFSET] = operator.raw_operator.offset_
-    extra_config[constants.IFOREST_THRESHOLD] = (
-        operator.raw_operator.threshold_ if hasattr(operator.raw_operator, "threshold_") else 0
-    )
+    if hasattr(operator.raw_operator, "threshold_"):
+        extra_config[constants.IFOREST_THRESHOLD] = operator.raw_operator.threshold_
     extra_config[constants.MAX_SAMPLES] = operator.raw_operator.max_samples_
 
     # Predict in isolation forest sklearn implementation produce 2 classes: -1 (normal) & 1 (anomaly).


### PR DESCRIPTION
fix #275 

[the predict function of sklearn <= 0.21](https://github.com/scikit-learn/scikit-learn/blob/0.21.X/sklearn/ensemble/iforest.py#L316) has a dependency on an extra attribute "threshold_", which was removed after 0.21. To make it compatible, parse this as constant if it exists otherwise set 0. Then change accordingly in the functions e.g. decision_function. Note that it's not possible to combine this value into the existing "offset" because only predict relies on "threshold", but decision_function & score_samples do not. Should works for sklearn >= 0.20