### PR TITLE
fixing copypaste bug in test resulted in some failures

### DIFF
--- a/tests/test_sklearn_nb_converter.py
+++ b/tests/test_sklearn_nb_converter.py
@@ -76,29 +76,29 @@ class TestSklearnNBClassifier(unittest.TestCase):
 
     # MultinomialNB binary
     def test_multinomialnb_classifer_bi(self):
-        self._test_bernoulinb_classifer(2)
+        self._test_multinomialnb_classifer(2)
 
     # MultinomialNB multi-class
     def test_multinomialnb_classifer_multi(self):
-        self._test_bernoulinb_classifer(3)
+        self._test_multinomialnb_classifer(3)
 
     # MultinomialNB multi-class w/ modified alpha
     def test_multinomialnb_classifer_multi_alpha(self):
-        self._test_bernoulinb_classifer(3, alpha=0.5)
+        self._test_multinomialnb_classifer(3, alpha=0.5)
 
     #  MultinomialNB multi-class w/ fir prior
     def test_multinomialnb_classifer_multi_fit_prior(self):
-        self._test_bernoulinb_classifer(3, fit_prior=True)
+        self._test_multinomialnb_classifer(3, fit_prior=True)
 
     #  MultinomialNB multi-class w/ class prior
     def test_multinomialnb_classifer_multi_class_prior(self):
         np.random.seed(0)
         class_prior = np.random.rand(3)
-        self._test_bernoulinb_classifer(3, class_prior=class_prior)
+        self._test_multinomialnb_classifer(3, class_prior=class_prior)
 
-    # BernoulliNB multi-class w/ labels shift
+    # MultinomialNB multi-class w/ labels shift
     def test_multinomialnb_classifer_multi_labels_shift(self):
-        self._test_bernoulinb_classifer(3, labels_shift=3)
+        self._test_multinomialnb_classifer(3, labels_shift=3)
 
     # GaussianNB test function to be parameterized
     def _test_gaussiannb_classifer(self, num_classes, priors=None, var_smoothing=1e-9, labels_shift=0):


### PR DESCRIPTION
I was going over coverage and I saw that the [nb.py coverage](https://codecov.io/gh/microsoft/hummingbird/src/master/hummingbird/ml/operator_converters/sklearn/nb.py) showed that `convert_sklearn_multinomial_naive_bayes` was not getting tested.  I saw that it was due to copy/paste error.

when i ran the test, i see the test fail...investigating...