### PR TITLE
Fix few issues with the benchmars

### DIFF
--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -120,7 +120,9 @@ def prepare_airline(dataset_folder, nrows):  # pylint: disable=too-many-locals
     y = df["ArrDelayBinary"]
     del df
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
-    data = Data(X_train.astype("|f4"), X_test.astype("|f4"), y_train, y_test, LearningTask.CLASSIFICATION)
+    data = Data(
+        X_train.astype("|f4").to_numpy(), X_test.astype("|f4").to_numpy(), y_train, y_test, LearningTask.CLASSIFICATION
+    )
     pickle.dump(data, open(pickle_url, "wb"), protocol=4)
     return data
 
@@ -141,7 +143,9 @@ def prepare_fraud(dataset_folder, nrows):
     X = df[[col for col in df.columns if col.startswith("V")]]
     y = df["Class"]
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
-    data = Data(X_train.astype("|f4"), X_test.astype("|f4"), y_train, y_test, LearningTask.CLASSIFICATION)
+    data = Data(
+        X_train.astype("|f4").to_numpy(), X_test.astype("|f4").to_numpy(), y_train, y_test, LearningTask.CLASSIFICATION
+    )
     pickle.dump(data, open(pickle_url, "wb"), protocol=4)
     return data
 
@@ -162,7 +166,9 @@ def prepare_higgs(dataset_folder, nrows):
     y = higgs.iloc[:, 0]
 
     X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
-    data = Data(X_train.astype("|f4"), X_test.astype("|f4"), y_train, y_test, LearningTask.CLASSIFICATION)
+    data = Data(
+        X_train.astype("|f4").to_numpy(), X_test.astype("|f4").to_numpy(), y_train, y_test, LearningTask.CLASSIFICATION
+    )
     pickle.dump(data, open(pickle_url, "wb"), protocol=4)
     return data
 
@@ -191,7 +197,7 @@ def prepare_year(dataset_folder, nrows):
         print("Warning: nrows is specified, not using predefined test/train split for " "YearPredictionMSD.")
         X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
 
-    data = Data(X_train.astype("|f4"), X_test.astype("|f4"), y_train, y_test, LearningTask.REGRESSION)
+    data = Data(X_train.astype("|f4").to_numpy(), X_test.astype("|f4").to_numpy(), y_train, y_test, LearningTask.REGRESSION)
     pickle.dump(data, open(pickle_url, "wb"), protocol=4)
     return data
 

--- a/benchmarks/pipelines/score.py
+++ b/benchmarks/pipelines/score.py
@@ -14,7 +14,7 @@ import hummingbird.ml
 
 class ScoreBackend(ABC):
     @staticmethod
-    def create(name):  # pylint: disable=too-many-return-statements
+    def create(name):
         if name in ["torch", "torch.jit", "onnx"]:
             return HBBackend(name)
         raise ValueError("Unknown backend: " + name)

--- a/benchmarks/trees/score.py
+++ b/benchmarks/trees/score.py
@@ -36,18 +36,19 @@ from hummingbird.ml import convert
 
 class ScoreBackend(ABC):
     @staticmethod
-    def create(name):  # pylint: disable=too-many-return-statements
+    def create(name):
         if name == "hb-pytorch":
-            return PytorchBackend()
+            return HBBackend("torch")
         if name == "hb-torchscript":
-            return TorchScriptBackend()
+            return HBBackend("torch.jit")
         if name == "hb-onnx":
-            return ONNXBackend()
+            return HBBackend("onnx")
         if name == "onnx-ml":
             return ONNXMLBackend()
         raise ValueError("Unknown backend: " + name)
 
     def __init__(self):
+        self.backend = None
         self.model = None
         self.params = {}
         self.predictions = None
@@ -91,14 +92,21 @@ class ScoreBackend(ABC):
         pass
 
 
-class PytorchBackend(ScoreBackend):
+class HBBackend(ScoreBackend):
+    def __init__(self, backend):
+        super().__init__()
+        self.backend = backend
+
     def convert(self, model, data, args, model_name):
         self.configure(data, model, args)
+
+        test_data = self.get_data(data.X_test)
 
         with Timer() as t:
             self.model = convert(
                 model,
-                "torch",
+                self.backend,
+                test_data,
                 device=self.params["device"],
                 extra_config={constants.N_THREADS: self.params["nthread"], constants.BATCH_SIZE: self.params["batch_size"]},
             )
@@ -115,43 +123,6 @@ class PytorchBackend(ScoreBackend):
             else:
                 self.predictions = self.model.predict_proba(predict_data)
 
-        return t.interval
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        del self.model
-
-
-class TorchScriptBackend(PytorchBackend):
-    def convert(self, model, data, args, model_name):
-        self.configure(data, model, args)
-        predict_data = self.get_data(data.X_test)
-
-        with Timer() as t:
-            self.model = convert(
-                model,
-                "torch.jit",
-                predict_data,
-                self.params["device"],
-                extra_config={constants.N_THREADS: self.params["nthread"], constants.BATCH_SIZE: self.params["batch_size"]},
-            )
-
-        return t.interval
-
-
-class ONNXBackend(PytorchBackend):
-    def convert(self, model, data, args, model_name):
-
-        self.configure(data, model, args)
-        predict_data = self.get_data(data.X_test)
-
-        with Timer() as t:
-            self.model = convert(
-                model,
-                "onnx",
-                predict_data,
-                self.params["device"],
-                extra_config={constants.N_THREADS: self.params["nthread"], constants.BATCH_SIZE: self.params["batch_size"]},
-            )
         return t.interval
 
     def __exit__(self, exc_type, exc_value, traceback):


### PR DESCRIPTION
Specifically: 
- xgboost converter needs input test data to get the number of features
- xgboost > 0.90 introduces feature names in the tree nodes when the datasets is in dataframe format. To make the benchmark generic, all datasets are no transformed into numpy arrays.

While doing the above, I also refactored the code (why not!)