### PR TITLE
[Benchmark] Add batch_benchmark option to do benchmark on a single batch (not on a whole data)

### DIFF
--- a/benchmarks/trees/metrics.py
+++ b/benchmarks/trees/metrics.py
@@ -37,14 +37,14 @@ import sklearn.metrics as sklm
 from benchmarks.datasets import LearningTask
 
 
-def get_metrics(data, pred):
-    if data.learning_task == LearningTask.REGRESSION:
-        return regression_metrics(data.y_test, pred)
-    if data.learning_task == LearningTask.CLASSIFICATION:
-        return classification_metrics(data.y_test, pred)
-    if data.learning_task == LearningTask.MULTICLASS_CLASSIFICATION:
-        return classification_metrics_multilabel(data.y_test, pred)
-    raise ValueError("No metrics defined for learning task: " + str(data.learning_task))
+def get_metrics(y_test, pred, learning_task):
+    if learning_task == LearningTask.REGRESSION:
+        return regression_metrics(y_test, pred)
+    if learning_task == LearningTask.CLASSIFICATION:
+        return classification_metrics(y_test, pred)
+    if learning_task == LearningTask.MULTICLASS_CLASSIFICATION:
+        return classification_metrics_multilabel(y_test, pred)
+    raise ValueError("No metrics defined for learning task: " + str(learning_task))
 
 
 def evaluate_metrics(y_true, y_pred, metrics):

--- a/benchmarks/trees/run.py
+++ b/benchmarks/trees/run.py
@@ -215,7 +215,7 @@ def benchmark(args, dataset_folder, model_folder, dataset):
         results[op] = {}
         model_name = op + "-" + str(args.ntrees) + "-" + str(args.cpus)
         model_full_name = os.path.join(model_folder, model_name + ".pkl")
-        trainer = train.TrainEnsembleAlgorithm.create(op)
+        trainer = train.TrainEnsembleAlgorithm.create(op, data.learning_task)
         test_data = get_data(data.X_test)
 
         with trainer:

--- a/benchmarks/trees/run.py
+++ b/benchmarks/trees/run.py
@@ -187,7 +187,7 @@ def parse_args():
         action="store_true",
         help=("Whether to do a single batch benchmark with specified batch_size and niters (not on the whole data)"),
     )
-    parser.add_argument("-maxdepth", default=None, type=int, help=("Maxmimum number of levels in the trees"))
+    parser.add_argument("-max_depth", default=8, type=int, help=("Maxmimum number of levels in the trees"))
     parser.add_argument(
         "-validate", default=False, action="store_true", help="Validate prediction output and fails accordingly."
     )
@@ -195,7 +195,7 @@ def parse_args():
     args = parser.parse_args()
     # Default value for output json file.
     if not args.output:
-        args.output = "result-{}-{}-{}.json".format("gpu" if args.gpu else args.cpus, args.ntrees, args.batch_size)
+        args.output = "result-{}-{}-{}-{}.json".format("gpu" if args.gpu else args.cpus, args.ntrees, args.max_depth, args.batch_size)
     return args
 
 
@@ -222,7 +222,7 @@ def benchmark(args, dataset_folder, model_folder, dataset):
     for op in operators.split(","):
         print("Running '%s' ..." % op)
         results[op] = {}
-        model_name = op + "-" + str(args.ntrees) + "-" + str(args.cpus)
+        model_name = op + "-" + str(args.ntrees) + "-" + str(args.max_depth) + "-" + str(args.cpus)
         model_full_name = os.path.join(model_folder, model_name + ".pkl")
         trainer = train.TrainEnsembleAlgorithm.create(op, data.learning_task)
         if args.batch_benchmark:

--- a/benchmarks/trees/run.py
+++ b/benchmarks/trees/run.py
@@ -181,6 +181,14 @@ def parse_args():
         ),
     )
     parser.add_argument("-niters", default=5, type=int, help=("Number of iterations for each experiment"))
+    parser.add_argument(
+        "-batch_benchmark",
+        default=False,
+        action="store_true",
+        help=("Whether to do a single batch benchmark with specified batch_size"
+              "and niters (not on the whole data)"
+              ),
+    )
     parser.add_argument("-maxdepth", default=None, type=int, help=("Maxmimum number of levels in the trees"))
     parser.add_argument(
         "-validate", default=False, action="store_true", help="Validate prediction output and fails accordingly."
@@ -197,9 +205,12 @@ def get_data(data, size=-1):
     np_data = data.to_numpy() if not isinstance(data, np.ndarray) else data
 
     if size != -1:
-        np_data = np_data[0:size, :]
+        msg = "Requested size bigger than the data size (%d vs %d)" % (size, np_data.shape[0])
+        assert size <= np_data.shape[0], msg
+        np_data = np_data[0:size]
 
     return np_data
+
 
 # Benchmarks a single dataset.
 def benchmark(args, dataset_folder, model_folder, dataset):
@@ -216,15 +227,21 @@ def benchmark(args, dataset_folder, model_folder, dataset):
         model_name = op + "-" + str(args.ntrees) + "-" + str(args.cpus)
         model_full_name = os.path.join(model_folder, model_name + ".pkl")
         trainer = train.TrainEnsembleAlgorithm.create(op, data.learning_task)
-        test_data = get_data(data.X_test)
+        if args.batch_benchmark:
+            test_size = args.batch_size
+        else:
+            test_size = data.X_test.shape[0]
+
+        X_test = get_data(data.X_test, size=test_size)
+        y_test = get_data(data.y_test, size=test_size)
 
         with trainer:
             if not os.path.exists(model_full_name):
                 train_time = trainer.fit(data, args)
-                pred = trainer.test(test_data)
+                pred = trainer.test(X_test)
                 results[op] = {
                     "train_time": str(train_time),
-                    "train_accuracy": str(get_metrics(data, pred)),
+                    "train_accuracy": str(get_metrics(y_test, pred, data.learning_task)),
                 }
                 model = trainer.model
                 if not os.path.exists(model_folder):
@@ -237,25 +254,18 @@ def benchmark(args, dataset_folder, model_folder, dataset):
             mean = 0
             mem = 0
 
-            for i in range(args.niters):
-                set_alarm(3600)
-                times.append(trainer.predict(model, test_data, args))
-                set_alarm(0)
-            mean = stats.trim_mean(times, 1 / len(times)) if args.niters > 1 else times[0]
-            gc.collect()
-            mem = max(memory_usage((trainer.predict, (model, test_data, args))))
+            try:
+                for i in range(args.niters):
+                    set_alarm(3600)
+                    times.append(trainer.predict(model, X_test, args))
+                    set_alarm(0)
+                mean = stats.trim_mean(times, 1 / len(times)) if args.niters > 1 else times[0]
+                gc.collect()
+                mem = max(memory_usage((trainer.predict, (model, X_test, args))))
+            except Exception as e:
+                print(e)
+                pass
 
-            # try:
-            #     for i in range(args.niters):
-            #         set_alarm(3600)
-            #         times.append(trainer.predict(model, predict_data, args))
-            #         set_alarm(0)
-            #     mean = stats.trim_mean(times, 1 / len(times)) if args.niters > 1 else times[0]
-            #     gc.collect()
-            #     mem = max(memory_usage((trainer.predict, (model, data, args))))
-            # except Exception as e:
-            #     print(e)
-            #     pass
             results[op].update({"prediction_time": mean})
             results[op].update({"peak_mem": mem})
             outer_ops = args.operator
@@ -279,29 +289,22 @@ def benchmark(args, dataset_folder, model_folder, dataset):
                 print("Running '%s' ..." % backend)
                 scorer = score.ScoreBackend.create(backend)
                 with scorer:
-                    conversion_time = scorer.convert(model, data, test_data, args, os.path.join(model_folder, model_name))
+                    conversion_time = scorer.convert(model, data, X_test, args, os.path.join(model_folder, model_name))
 
                     times = []
                     prediction_time = 0
-                    for i in range(args.niters):
-                        set_alarm(3600)
-                        times.append(scorer.predict(test_data))
-                        set_alarm(0)
-                    prediction_time = times[0] if args.niters == 1 else stats.trim_mean(times, 1 / len(times))
-                    gc.collect()
-                    mem = max(memory_usage((scorer.predict, (test_data,))))
 
-                    # try:
-                    #     for i in range(args.niters):
-                    #         set_alarm(3600)
-                    #         times.append(scorer.predict(data))
-                    #         set_alarm(0)
-                    #     prediction_time = times[0] if args.niters == 1 else stats.trim_mean(times, 1 / len(times))
-                    #     gc.collect()
-                    #     mem = max(memory_usage((scorer.predict, (data,))))
-                    # except Exception as e:
-                    #     print(e)
-                    #     pass
+                    try:
+                        for i in range(args.niters):
+                            set_alarm(3600)
+                            times.append(scorer.predict(X_test))
+                            set_alarm(0)
+                        prediction_time = times[0] if args.niters == 1 else stats.trim_mean(times, 1 / len(times))
+                        gc.collect()
+                        mem = max(memory_usage((scorer.predict, (X_test,))))
+                    except Exception as e:
+                        print(e)
+                        pass
 
                     results[op][backend] = {
                         "conversion_time": str(conversion_time),

--- a/benchmarks/trees/run.py
+++ b/benchmarks/trees/run.py
@@ -185,9 +185,7 @@ def parse_args():
         "-batch_benchmark",
         default=False,
         action="store_true",
-        help=("Whether to do a single batch benchmark with specified batch_size"
-              "and niters (not on the whole data)"
-              ),
+        help=("Whether to do a single batch benchmark with specified batch_size and niters (not on the whole data)"),
     )
     parser.add_argument("-maxdepth", default=None, type=int, help=("Maxmimum number of levels in the trees"))
     parser.add_argument(

--- a/benchmarks/trees/score.py
+++ b/benchmarks/trees/score.py
@@ -198,7 +198,7 @@ class ONNXMLBackend(ScoreBackend):
                 if self.params["operator"] == "xgb":
                     self.predictions[start:end, :] = sess.run([output_name], {input_name: predict_data[start:end, :]})
                 elif self.params["operator"] == "lgbm" or "rf":
-                    if i == iterations - 1 and self.remainder_model is not None:
+                    if total_size > batch_size and i == iterations - 1 and self.remainder_model is not None:
                         pred = remainder_sess.run([output_name], {input_name: predict_data[start:end, :]})
                     else:
                         pred = sess.run([output_name], {input_name: predict_data[start:end, :]})

--- a/benchmarks/trees/score.py
+++ b/benchmarks/trees/score.py
@@ -89,6 +89,7 @@ class HBBackend(ScoreBackend):
     def __init__(self, backend):
         super(HBBackend, self).__init__()
         self.backend = backend
+        self.predict_fn = None
 
     def convert(self, model, data, test_data, args, model_name):
         self.configure(data, model, args)
@@ -110,7 +111,7 @@ class HBBackend(ScoreBackend):
         return t.interval
 
     def predict(self, predict_data):
-        assert self.model is not None
+        assert self.predict_fn is not None
 
         with Timer() as t:
             self.predictions = self.predict_fn(predict_data)
@@ -130,7 +131,7 @@ class ONNXMLBackend(ScoreBackend):
         super(ONNXMLBackend, self).configure(data, model, args)
         self.params.update({"operator": args.operator})
 
-    def convert(self, model, data, args, model_name):
+    def convert(self, model, data, test_data, args, model_name):
         from onnxmltools.convert import convert_xgboost
         from onnxmltools.convert import convert_lightgbm
         from skl2onnx import convert_sklearn

--- a/benchmarks/trees/train.py
+++ b/benchmarks/trees/train.py
@@ -76,21 +76,25 @@ class TrainEnsembleAlgorithm(ABC):
         with Timer() as t:
             total_size = len(predict_data)
             iterations = total_size // batch_size
-            iterations += 1 if total_size % batch_size > 0 else 0
-            iterations = max(1, iterations)
 
-            if self.learning_task == LearningTask.CLASSIFICATION:
-                self.predictions = np.empty([total_size, 2], dtype="f4")
-            if self.learning_task == LearningTask.MULTICLASS_CLASSIFICATION:
-                self.predictions = np.empty([total_size, model.n_classes_], dtype="f4")
-            if self.learning_task == LearningTask.REGRESSION:
-                self.predictions = np.empty([total_size], dtype="f4")
+            if total_size == batch_size:
+                self.predictions = predict_fn(predict_data)
+            else:
+                iterations += 1 if total_size % batch_size > 0 else 0
+                iterations = max(1, iterations)
 
-            for i in range(0, iterations):
-                start = i * batch_size
-                end = min(start + batch_size, total_size)
-                batch = predict_data[start:end]
-                self.predictions[start:end] = predict_fn(batch)
+                if self.learning_task == LearningTask.CLASSIFICATION:
+                    self.predictions = np.empty([total_size, 2], dtype="f4")
+                if self.learning_task == LearningTask.MULTICLASS_CLASSIFICATION:
+                    self.predictions = np.empty([total_size, model.n_classes_], dtype="f4")
+                if self.learning_task == LearningTask.REGRESSION:
+                    self.predictions = np.empty([total_size], dtype="f4")
+
+                for i in range(0, iterations):
+                    start = i * batch_size
+                    end = min(start + batch_size, total_size)
+                    batch = predict_data[start:end]
+                    self.predictions[start:end] = predict_fn(batch)
 
         return t.interval
 

--- a/benchmarks/trees/train.py
+++ b/benchmarks/trees/train.py
@@ -138,6 +138,13 @@ class XgbAlgorithm(TrainEnsembleAlgorithm):
     def fit(self, data, args):
         params = self.configure(data, args)
 
+        tree_method = params["tree_method"]
+        predictor = "cpu_predictor"
+
+        if args.gpu:
+            tree_method = "gpu_hist"
+            predictor = "gpu_predictor"
+
         if data.learning_task == LearningTask.REGRESSION:
             self.model = xgb.XGBRegressor(
                 max_depth=params["max_depth"],
@@ -146,7 +153,8 @@ class XgbAlgorithm(TrainEnsembleAlgorithm):
                 learning_rate=params["learning_rate"],
                 objective=params["objective"],
                 nthread=params["nthread"],
-                tree_method=params["tree_method"],
+                predictor=predictor,
+                tree_method=tree_method,
                 reg_lambda=params["reg_lambda"],
                 **(params["args"])
             )
@@ -158,7 +166,8 @@ class XgbAlgorithm(TrainEnsembleAlgorithm):
                 learning_rate=params["learning_rate"],
                 objective=params["objective"],
                 nthread=params["nthread"],
-                tree_method=params["tree_method"],
+                predictor=predictor,
+                tree_method=tree_method,
                 reg_lambda=params["reg_lambda"],
                 **(params["args"])
             )

--- a/benchmarks/trees/train.py
+++ b/benchmarks/trees/train.py
@@ -103,14 +103,14 @@ class TrainEnsembleAlgorithm(ABC):
 
 
 # learning parameters shared by all algorithms, using the xgboost convention
-shared_params = {"max_depth": 8, "learning_rate": 0.1, "reg_lambda": 1}
+shared_params = {"learning_rate": 0.1, "reg_lambda": 1}
 
 
 class XgbAlgorithm(TrainEnsembleAlgorithm):
     def configure(self, data, args):
         params = shared_params.copy()
         params.update({"tree_method": "hist"})
-        params.update({"max_leaves": 256, "nthread": args.cpus, "ntrees": args.ntrees})
+        params.update({"max_leaves": 256, "nthread": args.cpus, "max_depth": args.max_depth, "ntrees": args.ntrees})
         if data.learning_task == LearningTask.REGRESSION:
             params["objective"] = "reg:squarederror"
             params["args"] = {}
@@ -175,7 +175,7 @@ class XgbAlgorithm(TrainEnsembleAlgorithm):
 class LgbmAlgorithm(TrainEnsembleAlgorithm):
     def configure(self, data, args):
         params = shared_params.copy()
-        params.update({"max_leaves": 256, "njobs": args.cpus, "ntrees": args.ntrees})
+        params.update({"max_leaves": 256, "njobs": args.cpus, "max_depth": args.max_depth, "ntrees": args.ntrees})
         if data.learning_task == LearningTask.REGRESSION:
             params["objective"] = "regression"
             params["args"] = {}
@@ -225,7 +225,7 @@ class LgbmAlgorithm(TrainEnsembleAlgorithm):
 class RandomForestAlgorithm(TrainEnsembleAlgorithm):
     def configure(self, data, args):
         params = shared_params.copy()
-        params.update({"njobs": args.cpus, "ntrees": args.ntrees})
+        params.update({"njobs": args.cpus, "ntrees": args.ntrees, "max_depth": args.max_depth})
         params.update(args.extra)
 
         return params

--- a/hummingbird/ml/_container.py
+++ b/hummingbird/ml/_container.py
@@ -97,6 +97,10 @@ class SklearnContainer(ABC):
         else:
             total_size = inputs.shape[0]
 
+        if total_size == self._batch_size:
+            # A single batch inference case
+            return function(*inputs)
+
         iterations = total_size // self._batch_size
         iterations += 1 if total_size % self._batch_size > 0 else 0
         iterations = max(1, iterations)


### PR DESCRIPTION
Also removed batch by batch prediction code in rf/xgb/lgm, since they can do prediction on the whole data in one go and that's how people use them.

If you want to benchmark scaling behavior wrt a specific batch size, you can use the new `batch_benchmark` option instead. I don't think it justifies to do batch by batch prediction just for the sake of doing prediction on the whole data. 

I think measuring the prediction time on the whole data vs benchmarking the scaling behavior wrt batch size are separate issues and we shouldn't conflate them.

@interesaaat 