### PR TITLE
black for any python3 (ex:python3.7), lint FIRST

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -29,6 +29,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Lint with flake8
       run: |
+        python -m pip install --upgrade pip
+        pip install flake8
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # The GitHub editor is 127 chars wide
@@ -50,7 +52,6 @@ jobs:
       run: pip install torch==1.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     - name: Install basic dependencies
       run: |
-        python -m pip install --upgrade pip
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
     - name: Run basic tests without extra
       run: pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -27,6 +27,12 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # The GitHub editor is 127 chars wide
+        flake8 . --count  --max-complexity=10 --max-line-length=127 --statistics
     # PyTorch for Mac has different pip syntax wrt Win and Linux.
     # PyTorch stop supporting python 3.5 from version 1.6.
     # The following cases address the situations above.
@@ -116,12 +122,6 @@ jobs:
       working-directory: ../../../incubator-tvm/python
       run: |
         python setup.py install
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # The GitHub editor is 127 chars wide
-        flake8 . --count  --max-complexity=10 --max-line-length=127 --statistics
     # We don't run pytest for Linux py3.7 since we do coverage for that case.
     - name: Test with pytest
       if: ${{ matrix.python-version != '3.7' || matrix.os != 'ubuntu-latest' }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: stable
     hooks:
     - id: black
-      language_version: python3.6
+      language_version: python3
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v1.2.3
     hooks:


### PR DESCRIPTION
- Our current `.black` setting mandates python3.6.  (I just upgraded to 3.7 and found my commit hooks broken!)

- Speaking of broken commit hooks, let's fail ASAP on lint fail!! ;-D