### PR TITLE
Fix to linear ONNX

### DIFF
--- a/hummingbird/ml/convert.py
+++ b/hummingbird/ml/convert.py
@@ -231,7 +231,7 @@ def _convert_onnxml(model, backend, test_input, device, extra_config={}):
             extra_config[constants.TEST_INPUT] = test_input
 
     # Set the number of features. Some converter requires to know in advance the number of features.
-    if constants.N_FEATURES not in extra_config:
+    if constants.N_FEATURES not in extra_config and test_input is not None:
         extra_config[constants.N_FEATURES] = test_input.shape[1]
     # Set the initializers. Some converter requires the access to initializers.
     initializers = {} if model.graph.initializer is None else {in_.name: in_ for in_ in model.graph.initializer}

--- a/hummingbird/ml/convert.py
+++ b/hummingbird/ml/convert.py
@@ -181,6 +181,11 @@ def _convert_onnxml(model, backend, test_input, device, extra_config={}):
                     raise RuntimeError("Cannot fetch input shape from ONNX schema. Please provide some test input.")
                 shape = [dim.dim_value for dim in input.type.tensor_type.shape.dim]
 
+                assert len(shape) == 2
+                # In ONNX dynamic dimensions will have a shape of 0. Fix the 0-shape in the batch dimension if they exist.
+                if shape[0] == 0:
+                    shape[0] = 1
+
                 if data_type == 1:
                     initial_types.append((name, FloatTensorType(shape)))
                 elif data_type == 11:
@@ -196,9 +201,6 @@ def _convert_onnxml(model, backend, test_input, device, extra_config={}):
                         )
                     )
 
-            assert all(
-                map(lambda x: len(x[1].shape) == 2, initial_types)
-            ), "Hummingbird currently supports only inputs with len(shape) == 2."
             first_shape = initial_types[0][1].shape
             assert all(
                 map(lambda x: x[1].shape == first_shape, initial_types)
@@ -208,15 +210,14 @@ def _convert_onnxml(model, backend, test_input, device, extra_config={}):
 
             test_input = []
             for i, it in enumerate(initial_types):
-                test_data = np.random.rand(first_shape[0], first_shape[1])
                 if type(it[1]) is FloatTensorType:
-                    test_input.append(np.array(test_data, dtype=np.float32))
+                    test_input.append(np.array(np.random.rand(first_shape[0], first_shape[1]), dtype=np.float32))
                 elif type(it[1]) is DoubleTensorType:
-                    test_input.append(np.array(test_data, dtype=np.float64))
+                    test_input.append(np.random.rand(first_shape[0], first_shape[1]))
                 elif type(it[1]) is Int32TensorType:
-                    test_input.append(np.array(test_data, dtype=np.int32))
+                    test_input.append(np.array(np.random.randint(100, size=first_shape), dtype=np.int32))
                 elif type(it[1]) is Int64TensorType:
-                    test_input.append(np.array(test_data, dtype=np.int64))
+                    test_input.append(np.random.randint(100, size=first_shape))
                 else:
                     raise RuntimeError(
                         "Type {} not supported. Please fill an issue on https://github.com/microsoft/hummingbird/.".format(

--- a/hummingbird/ml/operator_converters/_pipeline_implementations.py
+++ b/hummingbird/ml/operator_converters/_pipeline_implementations.py
@@ -22,16 +22,17 @@ class Concat(BaseOperator, torch.nn.Module):
 
     def forward(self, *x):
         if len(x[0].shape) > 1:
-            if LooseVersion(torch.__version__) < LooseVersion("1.6.0"):
-                # Concat for pytorch < 1.6.0 has problems when types don't match. We need to explictly cast the tensors.
-                dtypes = {t.dtype for t in x}
-                if len(dtypes) > 1:
-                    if torch.float64 in dtypes:
-                        x = [t.double() for t in x]
-                    else:
-                        raise RuntimeError(
-                            "Combination of data types for Concat input tensors not supported. Please fill an issue at https://github.com/microsoft/hummingbird."
-                        )
+            # We need to explictly cast the tensors if their types don't agree.
+            dtypes = {t.dtype for t in x}
+            if len(dtypes) > 1:
+                if torch.float64 in dtypes:
+                    x = [t.double() for t in x]
+                elif torch.float32 in dtypes:
+                    x = [t.float() for t in x]
+                else:
+                    raise RuntimeError(
+                        "Combination of data types for Concat input tensors not supported. Please fill an issue at https://github.com/microsoft/hummingbird."
+                    )
             return torch.cat(x, dim=1)
         else:
             return torch.stack(x, dim=1)

--- a/hummingbird/ml/operator_converters/_scaler_implementations.py
+++ b/hummingbird/ml/operator_converters/_scaler_implementations.py
@@ -25,10 +25,16 @@ class Scaler(BaseOperator, torch.nn.Module):
         self.scale = scale
 
         if offset is not None:
-            self.offset = torch.nn.Parameter(torch.DoubleTensor([offset]), requires_grad=False)
+            if offset.dtype == "float64":
+                self.offset = torch.nn.Parameter(torch.DoubleTensor([offset]), requires_grad=False)
+            else:
+                self.offset = torch.nn.Parameter(torch.FloatTensor([offset]), requires_grad=False)
 
         if scale is not None:
-            self.scale = torch.nn.Parameter(torch.DoubleTensor([scale]), requires_grad=False)
+            if scale.dtype == "float64":
+                self.scale = torch.nn.Parameter(torch.DoubleTensor([scale]), requires_grad=False)
+            else:
+                self.scale = torch.nn.Parameter(torch.FloatTensor([scale]), requires_grad=False)
 
     def forward(self, x):
         if self.offset is not None:

--- a/hummingbird/ml/operator_converters/constants.py
+++ b/hummingbird/ml/operator_converters/constants.py
@@ -35,9 +35,6 @@ REORDER_TREES = "reorder_trees"
 ONNX_INITIALIZERS = "onnx_initializers"
 """The initializers of the onnx model."""
 
-ONNX_INPUTS = "onnx_inputs"
-"""The input of the onnx model."""
-
 TVM_CONTEXT = "tvm_context"
 """The context for TVM containing information on the target."""
 

--- a/hummingbird/ml/operator_converters/onnx/linear.py
+++ b/hummingbird/ml/operator_converters/onnx/linear.py
@@ -40,7 +40,8 @@ def convert_onnx_linear_model(operator, device=None, extra_config={}):
         elif attr.name == "classlabels_ints":
             classes = np.array(attr.ints)
         elif attr.name == "multi_class":
-            if attr.i != 0:  # https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md#ai.onnx.ml.LinearClassifier
+            if len(classes) > 2 and attr.i != 0:
+                # https://github.com/onnx/onnx/blob/master/docs/Operators-ml.md#ai.onnx.ml.LinearClassifier
                 multi_class = "multinomial"
 
     if any(v is None for v in [coefficients, intercepts, classes]):

--- a/hummingbird/ml/operator_converters/onnx/tree_ensemble.py
+++ b/hummingbird/ml/operator_converters/onnx/tree_ensemble.py
@@ -175,17 +175,10 @@ def _get_tree_infos_from_tree_ensemble(operator, device=None, extra_config={}):
     """
     Base method for extracting parameters from `ai.onnx.ml.TreeEnsemble`s.
     """
-    assert constants.ONNX_INPUTS in extra_config or constants.N_FEATURES in extra_config
+    assert constants.N_FEATURES in extra_config
 
     # Get the number of features.
-    if constants.ONNX_INPUTS in extra_config:
-        inputs = extra_config[constants.ONNX_INPUTS]
-
-        assert operator.origin.input[0] in inputs
-
-        n_features = inputs[operator.origin.input[0]].type.tensor_type.shape.dim[1].dim_value
-    else:
-        n_features = extra_config[constants.N_FEATURES]
+    n_features = extra_config[constants.N_FEATURES]
 
     tree_infos, classes, post_transform = _get_tree_infos_from_onnx_ml_operator(operator)
 

--- a/hummingbird/ml/operator_converters/sklearn/scaler.py
+++ b/hummingbird/ml/operator_converters/sklearn/scaler.py
@@ -25,12 +25,12 @@ def convert_sklearn_max_abs_scaler(operator, device, extra_config):
     scale = operator.raw_operator.scale_
     if scale is not None:
         scale = np.reciprocal(scale)
-    return Scaler(0, scale, device)
+    return Scaler(np.array([0]), scale, device)
 
 
 def convert_sklearn_min_max_scaler(operator, device, extra_config):
-    scale = [x for x in operator.raw_operator.scale_]
-    offset = [-1.0 / x * y for x, y in zip(operator.raw_operator.scale_, operator.raw_operator.min_)]
+    scale = np.array([x for x in operator.raw_operator.scale_])
+    offset = np.array([-1.0 / x * y for x, y in zip(operator.raw_operator.scale_, operator.raw_operator.min_)])
     return Scaler(offset, scale, device)
 
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -138,6 +138,28 @@ class TestBackends(unittest.TestCase):
         hb_model = hummingbird.ml.convert(onnx_ml_model, "onnx")
         assert hb_model
 
+    # Test onnx 0 shape input
+    @unittest.skipIf(
+        not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test require ONNX, ORT and ONNXMLTOOLS"
+    )
+    def test_onnx_zero_shape_input(self):
+        warnings.filterwarnings("ignore")
+        max_depth = 10
+        num_classes = 2
+        model = GradientBoostingClassifier(n_estimators=10, max_depth=max_depth)
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        y = np.random.randint(num_classes, size=100)
+
+        model.fit(X, y)
+
+        # Create ONNX-ML model
+        onnx_ml_model = convert_sklearn(model, initial_types=[("input", DoubleTensorType([0, X.shape[1]]))], target_opset=11)
+
+        # Test onnx requires no test_data
+        hb_model = hummingbird.ml.convert(onnx_ml_model, "onnx")
+        assert hb_model
+
     # Test onnx no test_data, double input
     @unittest.skipIf(
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test require ONNX, ORT and ONNXMLTOOLS"


### PR DESCRIPTION
In linear model generated by the onnx converter we found that even is the task is binary classification, the `multi_class` field is to a value different than 0. This will trigger the multiclass code path. The PR fixes this by forcing multiclass only if the number of classes is > 2.