### PR TITLE
Default to f32 for torch tensors

### DIFF
--- a/hummingbird/ml/_topology.py
+++ b/hummingbird/ml/_topology.py
@@ -88,10 +88,7 @@ def _compile_tvm_model(topology, torch_model, trace_input, target, ctx, config, 
 
     ts_model = _jit_model(torch_model, trace_input, "cpu", extra_config)
     test_input = [
-        (
-            topology.raw_model.input_names[i],
-            trace_input[i].shape if type(trace_input) is tuple else trace_input.shape,
-        )
+        (topology.raw_model.input_names[i], trace_input[i].shape if type(trace_input) is tuple else trace_input.shape,)
         for i in range(len(topology.raw_model.input_names))
     ]
 
@@ -446,11 +443,11 @@ class _PyTorchBackendModel(torch.nn.Module, object):
                     inputs[i] = np.array(inputs[i])
                 if type(inputs[i]) is np.ndarray:
                     inputs[i] = torch.from_numpy(inputs[i])
-                    if inputs[i].dtype == torch.float64:
-                        # We convert double precision arrays into single precision. Sklearn does the same.
-                        inputs[i] = inputs[i].float()
                 elif type(inputs[i]) is not torch.Tensor:
                     raise RuntimeError("Inputer tensor {} of not supported type {}".format(input_name, type(inputs[i])))
+                if inputs[i].dtype == torch.float64:
+                    # We convert double precision arrays into single precision. Sklearn does the same.
+                    inputs[i] = inputs[i].float()
                 if device is not None and device.type != "cpu":
                     inputs[i] = inputs[i].to(device)
                 variable_map[input_name] = inputs[i]

--- a/hummingbird/ml/operator_converters/_scaler_implementations.py
+++ b/hummingbird/ml/operator_converters/_scaler_implementations.py
@@ -25,16 +25,10 @@ class Scaler(BaseOperator, torch.nn.Module):
         self.scale = scale
 
         if offset is not None:
-            if offset.dtype == "float64":
-                self.offset = torch.nn.Parameter(torch.DoubleTensor([offset]), requires_grad=False)
-            else:
-                self.offset = torch.nn.Parameter(torch.FloatTensor([offset]), requires_grad=False)
+            self.offset = torch.nn.Parameter(torch.FloatTensor([offset]), requires_grad=False)
 
         if scale is not None:
-            if scale.dtype == "float64":
-                self.scale = torch.nn.Parameter(torch.DoubleTensor([scale]), requires_grad=False)
-            else:
-                self.scale = torch.nn.Parameter(torch.FloatTensor([scale]), requires_grad=False)
+            self.scale = torch.nn.Parameter(torch.FloatTensor([scale]), requires_grad=False)
 
     def forward(self, x):
         if self.offset is not None:

--- a/hummingbird/ml/operator_converters/_scaler_implementations.py
+++ b/hummingbird/ml/operator_converters/_scaler_implementations.py
@@ -25,10 +25,16 @@ class Scaler(BaseOperator, torch.nn.Module):
         self.scale = scale
 
         if offset is not None:
-            self.offset = torch.nn.Parameter(torch.FloatTensor([offset]), requires_grad=False)
+            if offset.dtype == "float64":
+                self.offset = torch.nn.Parameter(torch.DoubleTensor([offset]), requires_grad=False)
+            else:
+                self.offset = torch.nn.Parameter(torch.FloatTensor([offset]), requires_grad=False)
 
         if scale is not None:
-            self.scale = torch.nn.Parameter(torch.FloatTensor([scale]), requires_grad=False)
+            if scale.dtype == "float64":
+                self.scale = torch.nn.Parameter(torch.DoubleTensor([scale]), requires_grad=False)
+            else:
+                self.scale = torch.nn.Parameter(torch.FloatTensor([scale]), requires_grad=False)
 
     def forward(self, x):
         if self.offset is not None:


### PR DESCRIPTION
I found that sometime we get some type error when inputs are float64 when we import from onnx. This PR makes sure that we always default f64 to f32 before evaluation.