### PR TITLE
Remove duplicated code

### DIFF
--- a/hummingbird/ml/operator_converters/_tree_commons.py
+++ b/hummingbird/ml/operator_converters/_tree_commons.py
@@ -305,7 +305,6 @@ def get_parameters_for_gemm_common(lefts, rights, features, thresholds, values, 
         features = [0, 0, 0]
         thresholds = [0, 0, 0]
         n_classes = values.shape[1]
-        n_classes = values.shape[1]
         values = np.array([np.zeros(n_classes), values[0], values[0]])
         values.reshape(3, n_classes)
 


### PR DESCRIPTION
The code for getting n_classes in method get_parameters_for_gemm_common is repeated twice. One should be removed.