### PR TITLE
Fixing test flakiness

### DIFF
--- a/tests/test_sklearn_multioutput_regression.py
+++ b/tests/test_sklearn_multioutput_regression.py
@@ -35,7 +35,7 @@ class TestSklearnMultioutputRegressor(unittest.TestCase):
 
                 torch_model = hummingbird.ml.convert(model, "torch")
                 self.assertTrue(torch_model is not None)
-                np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-5, atol=1e-5)
+                np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-4, atol=1e-5)
 
     # Test RegressorChain with different child learners
     def test_sklearn_regressor_chain(self):


### PR DESCRIPTION
The test `test_sklearn_multioutput_regressor` sometimes fails. This PR address this issue.

To find a solution, I collected samples of the differences in the values being compared in the assertion, from several test executions and computed the tail distribution. I computed the extreme percentiles to check how high can the differences be. 
These are the percentiles for the relative differences:

```
0.9 : 5.8e-5
0.99: 7.6e-5
0.999: 5e-5
0.9999: 1e-4
```

For this fix, I chose the 99.99th percentile. I think setting the bound using the statistical evaluation might be a good way to ensure the test is not flaky.

Do you guys think this makes sense? Please let me know if this looks good or if you have any other suggestions. Also, here I assume there are no bugs in the code under test.
