### PR TITLE
print warnings for old torch

### DIFF
--- a/hummingbird/ml/operator_converters/_gbdt_commons.py
+++ b/hummingbird/ml/operator_converters/_gbdt_commons.py
@@ -42,6 +42,15 @@ def convert_gbdt_classifier_common(
         n_classes -= 1
     if classes is None:
         classes = [i for i in range(n_classes)]
+    # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
+    if n_classes > 2:
+        from distutils.version import LooseVersion
+        import torch
+
+        if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+            import warnings
+
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass. See issue #10.")
     reorder_trees = True
     if constants.REORDER_TREES in extra_config:
         reorder_trees = extra_config[constants.REORDER_TREES]

--- a/hummingbird/ml/operator_converters/sklearn/decision_tree.py
+++ b/hummingbird/ml/operator_converters/sklearn/decision_tree.py
@@ -36,7 +36,7 @@ def convert_sklearn_random_forest_classifier(operator, device, extra_config):
     classes = operator.raw_operator.classes_.tolist()
 
     # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
-    if classes > 2:
+    if len(classes) > 2:
         from distutils.version import LooseVersion
         import torch
 

--- a/hummingbird/ml/operator_converters/sklearn/decision_tree.py
+++ b/hummingbird/ml/operator_converters/sklearn/decision_tree.py
@@ -35,6 +35,16 @@ def convert_sklearn_random_forest_classifier(operator, device, extra_config):
     n_features = operator.raw_operator.n_features_
     classes = operator.raw_operator.classes_.tolist()
 
+    # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
+    if classes > 2:
+        from distutils.version import LooseVersion
+        import torch
+
+        if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+            import warnings
+
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
+
     # For Sklearn Trees we need to know how many trees are there for normalization.
     extra_config[constants.NUM_TREES] = len(tree_infos)
 

--- a/hummingbird/ml/operator_converters/sklearn/decision_tree.py
+++ b/hummingbird/ml/operator_converters/sklearn/decision_tree.py
@@ -43,7 +43,7 @@ def convert_sklearn_random_forest_classifier(operator, device, extra_config):
         if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
             import warnings
 
-            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass. See issue #10.")
 
     # For Sklearn Trees we need to know how many trees are there for normalization.
     extra_config[constants.NUM_TREES] = len(tree_infos)

--- a/hummingbird/ml/operator_converters/sklearn/linear.py
+++ b/hummingbird/ml/operator_converters/sklearn/linear.py
@@ -33,7 +33,7 @@ def convert_sklearn_linear_model(operator, device, extra_config):
     supported_loss = {"log", "modified_huber", "squared_hinge"}
     classes = [0] if not hasattr(operator.raw_operator, "classes_") else operator.raw_operator.classes_
     # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
-    if classes > 2:
+    if len(classes) > 2:
         from distutils.version import LooseVersion
         import torch
 

--- a/hummingbird/ml/operator_converters/sklearn/linear.py
+++ b/hummingbird/ml/operator_converters/sklearn/linear.py
@@ -40,7 +40,7 @@ def convert_sklearn_linear_model(operator, device, extra_config):
         if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
             import warnings
 
-            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass. See issue #10.")
 
     if not all(["int" in str(type(x)) for x in classes]):
         raise RuntimeError(

--- a/hummingbird/ml/operator_converters/sklearn/linear.py
+++ b/hummingbird/ml/operator_converters/sklearn/linear.py
@@ -32,6 +32,15 @@ def convert_sklearn_linear_model(operator, device, extra_config):
 
     supported_loss = {"log", "modified_huber", "squared_hinge"}
     classes = [0] if not hasattr(operator.raw_operator, "classes_") else operator.raw_operator.classes_
+    # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
+    if classes > 2:
+        from distutils.version import LooseVersion
+        import torch
+
+        if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+            import warnings
+
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
 
     if not all(["int" in str(type(x)) for x in classes]):
         raise RuntimeError(

--- a/hummingbird/ml/operator_converters/sklearn/mlp.py
+++ b/hummingbird/ml/operator_converters/sklearn/mlp.py
@@ -31,7 +31,7 @@ def convert_sklearn_mlp_classifier(operator, device, extra_config):
 
     classes = operator.raw_operator.classes_
     # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
-    if classes > 2:
+    if len(classes) > 2:
         from distutils.version import LooseVersion
         import torch
 

--- a/hummingbird/ml/operator_converters/sklearn/mlp.py
+++ b/hummingbird/ml/operator_converters/sklearn/mlp.py
@@ -38,7 +38,7 @@ def convert_sklearn_mlp_classifier(operator, device, extra_config):
         if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
             import warnings
 
-            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass. See issue #10.")
 
     if not all([type(x) in [int, np.int32, np.int64] for x in classes]):
         raise RuntimeError("Hummingbird supports only integer labels for class labels.")

--- a/hummingbird/ml/operator_converters/sklearn/mlp.py
+++ b/hummingbird/ml/operator_converters/sklearn/mlp.py
@@ -30,6 +30,16 @@ def convert_sklearn_mlp_classifier(operator, device, extra_config):
     assert operator is not None, "Cannot convert None operator"
 
     classes = operator.raw_operator.classes_
+    # There is a bug in torch < 1.7.0 that causes a mismatch. See Issue #10
+    if classes > 2:
+        from distutils.version import LooseVersion
+        import torch
+
+        if LooseVersion(torch.__version__) < LooseVersion("1.7.0"):
+            import warnings
+
+            warnings.warn("torch < 1.7.0 may give a mismatch on multiclass RF. See issue #10.")
+
     if not all([type(x) in [int, np.int32, np.int64] for x in classes]):
         raise RuntimeError("Hummingbird supports only integer labels for class labels.")
 


### PR DESCRIPTION
Closes #474 

TODO: make sure these get hit in codecov; we are only testing older `torch` (`1.5.1`) with older python (3.6)