### PR TITLE
Fix error when pandas is passed as input to predict but no test_input is used at convert time

### DIFF
--- a/hummingbird/ml/_executor.py
+++ b/hummingbird/ml/_executor.py
@@ -58,25 +58,37 @@ class Executor(torch.nn.Module, object):
         self._output_names = _fix_var_naming(reversed(operators), output_names, "output")
         self._operators = torch.nn.ModuleList([operator_map[operator.full_name] for operator in operators])
         self.max_string_length = None
+        self.check_dataframe_to_array = constants.TEST_INPUT not in extra_config
 
         if constants.MAX_STRING_LENGTH in extra_config:
             self.max_string_length = extra_config[constants.MAX_STRING_LENGTH]
 
     def forward(self, *inputs):
         with torch.no_grad():
-            assert len(self._input_names) == len(inputs) or (
-                type(inputs[0]) == DataFrame and DataFrame is not None and len(self._input_names) == len(inputs[0].columns)
+            assert (
+                len(self._input_names) == len(inputs)
+                or (type(inputs[0]) == DataFrame and DataFrame is not None and self.check_dataframe_to_array)
+                or (
+                    type(inputs[0]) == DataFrame
+                    and DataFrame is not None
+                    and not self.check_dataframe_to_array
+                    and len(self._input_names) == len(inputs[0].columns)
+                )
             ), "number of inputs or number of columns in the dataframe do not match with the expected number of inputs {}".format(
                 self._input_names
             )
 
             if type(inputs[0]) == DataFrame and DataFrame is not None:
-                # Split the dataframe into column ndarrays
-                inputs = inputs[0]
-                input_names = list(inputs.columns)
-                splits = [inputs[input_names[idx]] for idx in range(len(input_names))]
-                splits = [df.to_numpy().reshape(-1, 1) for df in splits]
-                inputs = tuple(splits)
+                if self.check_dataframe_to_array:
+                    # We were expecting a numpy array as input but we got a dataframe: call values() on it to get the array.
+                    inputs = inputs[0].values()
+                else:
+                    # Split the dataframe into column ndarrays.
+                    inputs = inputs[0]
+                    input_names = list(inputs.columns)
+                    splits = [inputs[input_names[idx]] for idx in range(len(input_names))]
+                    splits = [df.to_numpy().reshape(-1, 1) for df in splits]
+                    inputs = tuple(splits)
             inputs = [*inputs]
             variable_map = {}
             device = get_device(self)

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -20,287 +20,287 @@ if pandas_installed():
 
 class TestSklearnLinearClassifiers(unittest.TestCase):
 
-    # # LogisticRegression test function to be parameterized
-    # def _test_logistic_regression(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
-    #     if num_classes > 2:
-    #         model = LogisticRegression(solver=solver, multi_class=multi_class, fit_intercept=True)
-    #     else:
-    #         model = LogisticRegression(solver="liblinear", fit_intercept=True)
-
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(num_classes, size=100) + labels_shift
-
-    #     model.fit(X, y)
-
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # # LogisticRegression binary
-    # def test_logistic_regression_bi(self):
-    #     self._test_logistic_regression(2)
-
-    # # LogisticRegression multiclass with auto
-    # def test_logistic_regression_multi_auto(self):
-    #     self._test_logistic_regression(3)
-
-    # # LogisticRegression with class labels shifted
-    # def test_logistic_regression_shifted_classes(self):
-    #     self._test_logistic_regression(3, labels_shift=2)
-
-    # # LogisticRegression with multi+ovr
-    # def test_logistic_regression_multi_ovr(self):
-    #     self._test_logistic_regression(3, multi_class="ovr")
-
-    # # LogisticRegression with multi+multinomial+sag
-    # def test_logistic_regression_multi_multin_sag(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression(3, multi_class="multinomial", solver="sag")
-
-    # # LogisticRegression binary lbfgs
-    # def test_logistic_regression_bi_lbfgs(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression(2, solver="lbfgs")
-
-    # # LogisticRegression with multi+lbfgs
-    # def test_logistic_regression_multi_lbfgs(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression(3, solver="lbfgs")
-
-    # # LogisticRegression with multi+multinomial+lbfgs
-    # def test_logistic_regression_multi_multin_lbfgs(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression(3, multi_class="multinomial", solver="lbfgs")
-
-    # # LogisticRegression with multi+ovr+lbfgs
-    # def test_logistic_regression_multi_ovr_lbfgs(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression(3, multi_class="ovr", solver="lbfgs")
-
-    # # LinearRegression test function to be parameterized
-    # def _test_linear_regression(self, y_input):
-    #     model = LinearRegression()
-
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = y_input
-
-    #     model.fit(X, y)
-
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # # LinearRegression with ints
-    # def test_linear_regression_int(self):
-    #     np.random.seed(0)
-    #     self._test_linear_regression(np.random.randint(2, size=100))
-
-    # # LinearRegression with floats
-    # def test_linear_regression_float(self):
-    #     np.random.seed(0)
-    #     self._test_linear_regression(np.random.rand(100))
-
-    # # RidgeCV test function to be parameterized
-    # def _test_ridge_cv(self, y_input):
-    #     model = RidgeCV()
-
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = y_input
-
-    #     model.fit(X, y)
-
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # # RidgeCV with ints
-    # def test_ridge_cv_int(self):
-    #     np.random.seed(0)
-    #     self._test_ridge_cv(np.random.randint(2, size=100))
-
-    # # RidgeCV with floats
-    # def test_ridge_cv_float(self):
-    #     np.random.seed(0)
-    #     self._test_ridge_cv(np.random.rand(100))
-
-    # # LogisticRegressionCV test function to be parameterized
-    # def _test_logistic_regression_cv(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
-    #     if num_classes > 2:
-    #         model = LogisticRegressionCV(solver=solver, multi_class=multi_class, fit_intercept=True)
-    #     else:
-    #         model = LogisticRegressionCV(solver="liblinear", fit_intercept=True)
-
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(num_classes, size=100) + labels_shift
-
-    #     model.fit(X, y)
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # # LogisticRegressionCV with 2 classes
-    # def test_logistic_regression_cv_bi(self):
-    #     self._test_logistic_regression_cv(2)
-
-    # # LogisticRegressionCV with 3 classes
-    # def test_logistic_regression_cv_multi(self):
-    #     self._test_logistic_regression_cv(3)
-
-    # # LogisticRegressionCV with shifted classes
-    # def test_logistic_regression_cv_shifted_classes(self):
-    #     self._test_logistic_regression_cv(3, labels_shift=2)
-
-    # # LogisticRegressionCV with multi+ovr
-    # def test_logistic_regression_cv_multi_ovr(self):
-    #     self._test_logistic_regression_cv(3, multi_class="ovr")
-
-    # # LogisticRegressionCV with multi+multinomial
-    # def test_logistic_regression_cv_multi_multin(self):
-    #     warnings.filterwarnings("ignore")
-    #     # this will not converge due to small test size
-    #     self._test_logistic_regression_cv(3, multi_class="multinomial", solver="sag")
-
-    # # SGDClassifier test function to be parameterized
-    # def _test_sgd_classifier(self, num_classes):
+    # LogisticRegression test function to be parameterized
+    def _test_logistic_regression(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
+        if num_classes > 2:
+            model = LogisticRegression(solver=solver, multi_class=multi_class, fit_intercept=True)
+        else:
+            model = LogisticRegression(solver="liblinear", fit_intercept=True)
+
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(num_classes, size=100) + labels_shift
+
+        model.fit(X, y)
+
+        torch_model = hummingbird.ml.convert(model, "torch")
+
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # LogisticRegression binary
+    def test_logistic_regression_bi(self):
+        self._test_logistic_regression(2)
+
+    # LogisticRegression multiclass with auto
+    def test_logistic_regression_multi_auto(self):
+        self._test_logistic_regression(3)
+
+    # LogisticRegression with class labels shifted
+    def test_logistic_regression_shifted_classes(self):
+        self._test_logistic_regression(3, labels_shift=2)
+
+    # LogisticRegression with multi+ovr
+    def test_logistic_regression_multi_ovr(self):
+        self._test_logistic_regression(3, multi_class="ovr")
+
+    # LogisticRegression with multi+multinomial+sag
+    def test_logistic_regression_multi_multin_sag(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, multi_class="multinomial", solver="sag")
+
+    # LogisticRegression binary lbfgs
+    def test_logistic_regression_bi_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(2, solver="lbfgs")
+
+    # LogisticRegression with multi+lbfgs
+    def test_logistic_regression_multi_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, solver="lbfgs")
+
+    # LogisticRegression with multi+multinomial+lbfgs
+    def test_logistic_regression_multi_multin_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, multi_class="multinomial", solver="lbfgs")
+
+    # LogisticRegression with multi+ovr+lbfgs
+    def test_logistic_regression_multi_ovr_lbfgs(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression(3, multi_class="ovr", solver="lbfgs")
+
+    # LinearRegression test function to be parameterized
+    def _test_linear_regression(self, y_input):
+        model = LinearRegression()
+
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = y_input
+
+        model.fit(X, y)
+
+        torch_model = hummingbird.ml.convert(model, "torch")
+
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # LinearRegression with ints
+    def test_linear_regression_int(self):
+        np.random.seed(0)
+        self._test_linear_regression(np.random.randint(2, size=100))
+
+    # LinearRegression with floats
+    def test_linear_regression_float(self):
+        np.random.seed(0)
+        self._test_linear_regression(np.random.rand(100))
+
+    # RidgeCV test function to be parameterized
+    def _test_ridge_cv(self, y_input):
+        model = RidgeCV()
+
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = y_input
+
+        model.fit(X, y)
+
+        torch_model = hummingbird.ml.convert(model, "torch")
+
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # RidgeCV with ints
+    def test_ridge_cv_int(self):
+        np.random.seed(0)
+        self._test_ridge_cv(np.random.randint(2, size=100))
+
+    # RidgeCV with floats
+    def test_ridge_cv_float(self):
+        np.random.seed(0)
+        self._test_ridge_cv(np.random.rand(100))
+
+    # LogisticRegressionCV test function to be parameterized
+    def _test_logistic_regression_cv(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
+        if num_classes > 2:
+            model = LogisticRegressionCV(solver=solver, multi_class=multi_class, fit_intercept=True)
+        else:
+            model = LogisticRegressionCV(solver="liblinear", fit_intercept=True)
+
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(num_classes, size=100) + labels_shift
+
+        model.fit(X, y)
+        torch_model = hummingbird.ml.convert(model, "torch")
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # LogisticRegressionCV with 2 classes
+    def test_logistic_regression_cv_bi(self):
+        self._test_logistic_regression_cv(2)
+
+    # LogisticRegressionCV with 3 classes
+    def test_logistic_regression_cv_multi(self):
+        self._test_logistic_regression_cv(3)
+
+    # LogisticRegressionCV with shifted classes
+    def test_logistic_regression_cv_shifted_classes(self):
+        self._test_logistic_regression_cv(3, labels_shift=2)
+
+    # LogisticRegressionCV with multi+ovr
+    def test_logistic_regression_cv_multi_ovr(self):
+        self._test_logistic_regression_cv(3, multi_class="ovr")
+
+    # LogisticRegressionCV with multi+multinomial
+    def test_logistic_regression_cv_multi_multin(self):
+        warnings.filterwarnings("ignore")
+        # this will not converge due to small test size
+        self._test_logistic_regression_cv(3, multi_class="multinomial", solver="sag")
+
+    # SGDClassifier test function to be parameterized
+    def _test_sgd_classifier(self, num_classes):
 
-    #     model = SGDClassifier(loss="log")
+        model = SGDClassifier(loss="log")
 
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(num_classes, size=100)
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(num_classes, size=100)
 
-    #     model.fit(X, y)
+        model.fit(X, y)
 
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+        torch_model = hummingbird.ml.convert(model, "torch")
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-    # # SGDClassifier with 2 classes
-    # def test_sgd_classifier_bi(self):
-    #     self._test_sgd_classifier(2)
-
-    # # SGDClassifier with 3 classes
-    # def test_sgd_classifier_multi(self):
-    #     self._test_sgd_classifier(3)
-
-    # # SGDClassifier with modified huber loss
-    # @unittest.skipIf(
-    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    # )
-    # def test_modified_huber(self):
-    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-    #     Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
-
-    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-    #     model.fit(X, Y)
-
-    #     # Use Hummingbird to convert the model to PyTorch
-    #     hb_model = hummingbird.ml.convert(model, "torch")
-
-    #     inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
-    #     np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
-
-    # @unittest.skipIf(
-    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    # )
-    # def test_modified_huber2(self):
-    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-    #     Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
-
-    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-    #     model.fit(X, Y)
-
-    #     # Use Hummingbird to convert the model to PyTorch
-    #     hb_model = hummingbird.ml.convert(model, "torch")
-
-    #     np.testing.assert_allclose(model.predict_proba(X), hb_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # # SGDClassifier with modified huber loss multiclass
-    # @unittest.skipIf(
-    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    # )
-    # def test_modified_huber_multi(self):
-    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-    #     Y = np.array([0, 1, 1, 1, 2, 2, 2, 2])
-
-    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-    #     model.fit(X, Y)
-
-    #     # Use Hummingbird to convert the model to PyTorch
-    #     hb_model = hummingbird.ml.convert(model, "torch")
-
-    #     inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
-    #     np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
-
-    # # Failure cases
-    # def test_sklearn_linear_model_raises_wrong_type(self):
-    #     warnings.filterwarnings("ignore")
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(3, size=100).astype(np.float32)  # y must be int, not float, should error
-    #     model = SGDClassifier().fit(X, y)
-    #     self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "torch")
-
-    # # Float 64 data tests
-    # def test_float64_linear_regression(self):
-    #     model = LinearRegression()
-
-    #     np.random.seed(0)
-    #     X = np.random.rand(100, 200)
-    #     y = np.random.randint(2, size=100)
-
-    #     model.fit(X, y)
-
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # def test_float64_sgd_classifier(self):
-
-    #     model = SGDClassifier(loss="log")
-
-    #     np.random.seed(0)
-    #     num_classes = 3
-    #     X = np.random.rand(100, 200)
-    #     y = np.random.randint(num_classes, size=100)
-
-    #     model.fit(X, y)
-
-    #     torch_model = hummingbird.ml.convert(model, "torch")
-    #     self.assertTrue(torch_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # # Multioutput regression tests
-    # def test_multioutput_linear_regression(self):
-    #     for n_targets in [1, 2, 7]:
-    #         model = LinearRegression()
-    #         X, y = datasets.make_regression(
-    #             n_samples=100, n_features=10, n_informative=5, n_targets=n_targets, random_state=2021
-    #         )
-    #         model.fit(X, y)
-
-    #         torch_model = hummingbird.ml.convert(model, "torch")
-    #         self.assertTrue(torch_model is not None)
-    #         np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-5, atol=1e-5)
+    # SGDClassifier with 2 classes
+    def test_sgd_classifier_bi(self):
+        self._test_sgd_classifier(2)
+
+    # SGDClassifier with 3 classes
+    def test_sgd_classifier_multi(self):
+        self._test_sgd_classifier(3)
+
+    # SGDClassifier with modified huber loss
+    @unittest.skipIf(
+        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    )
+    def test_modified_huber(self):
+        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+        Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
+
+        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+        model.fit(X, Y)
+
+        # Use Hummingbird to convert the model to PyTorch
+        hb_model = hummingbird.ml.convert(model, "torch")
+
+        inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
+        np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
+
+    @unittest.skipIf(
+        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    )
+    def test_modified_huber2(self):
+        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+        Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
+
+        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+        model.fit(X, Y)
+
+        # Use Hummingbird to convert the model to PyTorch
+        hb_model = hummingbird.ml.convert(model, "torch")
+
+        np.testing.assert_allclose(model.predict_proba(X), hb_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # SGDClassifier with modified huber loss multiclass
+    @unittest.skipIf(
+        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    )
+    def test_modified_huber_multi(self):
+        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+        Y = np.array([0, 1, 1, 1, 2, 2, 2, 2])
+
+        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+        model.fit(X, Y)
+
+        # Use Hummingbird to convert the model to PyTorch
+        hb_model = hummingbird.ml.convert(model, "torch")
+
+        inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
+        np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
+
+    # Failure cases
+    def test_sklearn_linear_model_raises_wrong_type(self):
+        warnings.filterwarnings("ignore")
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(3, size=100).astype(np.float32)  # y must be int, not float, should error
+        model = SGDClassifier().fit(X, y)
+        self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "torch")
+
+    # Float 64 data tests
+    def test_float64_linear_regression(self):
+        model = LinearRegression()
+
+        np.random.seed(0)
+        X = np.random.rand(100, 200)
+        y = np.random.randint(2, size=100)
+
+        model.fit(X, y)
+
+        torch_model = hummingbird.ml.convert(model, "torch")
+
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    def test_float64_sgd_classifier(self):
+
+        model = SGDClassifier(loss="log")
+
+        np.random.seed(0)
+        num_classes = 3
+        X = np.random.rand(100, 200)
+        y = np.random.randint(num_classes, size=100)
+
+        model.fit(X, y)
+
+        torch_model = hummingbird.ml.convert(model, "torch")
+        self.assertTrue(torch_model is not None)
+        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # Multioutput regression tests
+    def test_multioutput_linear_regression(self):
+        for n_targets in [1, 2, 7]:
+            model = LinearRegression()
+            X, y = datasets.make_regression(
+                n_samples=100, n_features=10, n_informative=5, n_targets=n_targets, random_state=2021
+            )
+            model.fit(X, y)
+
+            torch_model = hummingbird.ml.convert(model, "torch")
+            self.assertTrue(torch_model is not None)
+            np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-5, atol=1e-5)
 
     # Test Pandas input
     @unittest.skipIf(not pandas_installed(), reason="Test requires pandas installed")
@@ -322,58 +322,58 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
         np.testing.assert_allclose(model.predict(X_train), hb_model.predict(X_train), rtol=1e-6, atol=1e-6)
         np.testing.assert_allclose(model.predict_proba(X_train), hb_model.predict_proba(X_train), rtol=1e-6, atol=1e-6)
 
-    # # Test Torschscript backend.
-    # def test_logistic_regression_ts(self):
+    # Test Torschscript backend.
+    def test_logistic_regression_ts(self):
 
-    #     model = LogisticRegression(solver="liblinear")
+        model = LogisticRegression(solver="liblinear")
 
-    #     data = datasets.load_iris()
-    #     X, y = data.data, data.target
-    #     X = X.astype(np.float32)
+        data = datasets.load_iris()
+        X, y = data.data, data.target
+        X = X.astype(np.float32)
 
-    #     model.fit(X, y)
+        model.fit(X, y)
 
-    #     ts_model = hummingbird.ml.convert(model, "torch.jit", X)
-    #     self.assertTrue(ts_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), ts_model.predict(X), rtol=1e-6, atol=1e-6)
-    #     np.testing.assert_allclose(model.predict_proba(X), ts_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+        ts_model = hummingbird.ml.convert(model, "torch.jit", X)
+        self.assertTrue(ts_model is not None)
+        np.testing.assert_allclose(model.predict(X), ts_model.predict(X), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(model.predict_proba(X), ts_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-    # # Test TVM backends.
-    # @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
-    # def test_sgd_classifier_tvm(self):
+    # Test TVM backends.
+    @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
+    def test_sgd_classifier_tvm(self):
 
-    #     model = SGDClassifier(loss="log")
+        model = SGDClassifier(loss="log")
 
-    #     np.random.seed(0)
-    #     num_classes = 3
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(num_classes, size=100)
+        np.random.seed(0)
+        num_classes = 3
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(num_classes, size=100)
 
-    #     model.fit(X, y)
+        model.fit(X, y)
 
-    #     tvm_model = hummingbird.ml.convert(model, "tvm", X)
-    #     self.assertTrue(tvm_model is not None)
-    #     np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-6)
-    #     np.testing.assert_allclose(model.predict_proba(X), tvm_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+        tvm_model = hummingbird.ml.convert(model, "tvm", X)
+        self.assertTrue(tvm_model is not None)
+        np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(model.predict_proba(X), tvm_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-    # @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
-    # def test_lr_tvm(self):
+    @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
+    def test_lr_tvm(self):
 
-    #     model = LinearRegression()
+        model = LinearRegression()
 
-    #     np.random.seed(0)
-    #     num_classes = 1000
-    #     X = np.random.rand(100, 200)
-    #     X = np.array(X, dtype=np.float32)
-    #     y = np.random.randint(num_classes, size=100)
+        np.random.seed(0)
+        num_classes = 1000
+        X = np.random.rand(100, 200)
+        X = np.array(X, dtype=np.float32)
+        y = np.random.randint(num_classes, size=100)
 
-    #     model.fit(X, y)
+        model.fit(X, y)
 
-    #     tvm_model = hummingbird.ml.convert(model, "tvm", X, extra_config={constants.TVM_MAX_FUSE_DEPTH: 30})
-    #     self.assertTrue(tvm_model is not None)
+        tvm_model = hummingbird.ml.convert(model, "tvm", X, extra_config={constants.TVM_MAX_FUSE_DEPTH: 30})
+        self.assertTrue(tvm_model is not None)
 
-    #     np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-3)
+        np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-3)
 
 
 if __name__ == "__main__":

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -11,346 +11,369 @@ from sklearn.linear_model import LinearRegression, LogisticRegression, SGDClassi
 from sklearn import datasets
 
 import hummingbird.ml
-from hummingbird.ml._utils import tvm_installed
+from hummingbird.ml._utils import tvm_installed, pandas_installed
 from hummingbird.ml import constants
+
+if pandas_installed():
+    import pandas
 
 
 class TestSklearnLinearClassifiers(unittest.TestCase):
 
-    # LogisticRegression test function to be parameterized
-    def _test_logistic_regression(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
-        if num_classes > 2:
-            model = LogisticRegression(solver=solver, multi_class=multi_class, fit_intercept=True)
-        else:
-            model = LogisticRegression(solver="liblinear", fit_intercept=True)
-
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(num_classes, size=100) + labels_shift
-
-        model.fit(X, y)
-
-        torch_model = hummingbird.ml.convert(model, "torch")
-
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # LogisticRegression binary
-    def test_logistic_regression_bi(self):
-        self._test_logistic_regression(2)
-
-    # LogisticRegression multiclass with auto
-    def test_logistic_regression_multi_auto(self):
-        self._test_logistic_regression(3)
-
-    # LogisticRegression with class labels shifted
-    def test_logistic_regression_shifted_classes(self):
-        self._test_logistic_regression(3, labels_shift=2)
-
-    # LogisticRegression with multi+ovr
-    def test_logistic_regression_multi_ovr(self):
-        self._test_logistic_regression(3, multi_class="ovr")
-
-    # LogisticRegression with multi+multinomial+sag
-    def test_logistic_regression_multi_multin_sag(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression(3, multi_class="multinomial", solver="sag")
-
-    # LogisticRegression binary lbfgs
-    def test_logistic_regression_bi_lbfgs(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression(2, solver="lbfgs")
-
-    # LogisticRegression with multi+lbfgs
-    def test_logistic_regression_multi_lbfgs(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression(3, solver="lbfgs")
-
-    # LogisticRegression with multi+multinomial+lbfgs
-    def test_logistic_regression_multi_multin_lbfgs(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression(3, multi_class="multinomial", solver="lbfgs")
-
-    # LogisticRegression with multi+ovr+lbfgs
-    def test_logistic_regression_multi_ovr_lbfgs(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression(3, multi_class="ovr", solver="lbfgs")
-
-    # LinearRegression test function to be parameterized
-    def _test_linear_regression(self, y_input):
-        model = LinearRegression()
-
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = y_input
-
-        model.fit(X, y)
-
-        torch_model = hummingbird.ml.convert(model, "torch")
-
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # LinearRegression with ints
-    def test_linear_regression_int(self):
-        np.random.seed(0)
-        self._test_linear_regression(np.random.randint(2, size=100))
-
-    # LinearRegression with floats
-    def test_linear_regression_float(self):
-        np.random.seed(0)
-        self._test_linear_regression(np.random.rand(100))
-
-    # RidgeCV test function to be parameterized
-    def _test_ridge_cv(self, y_input):
-        model = RidgeCV()
-
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = y_input
-
-        model.fit(X, y)
-
-        torch_model = hummingbird.ml.convert(model, "torch")
-
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # RidgeCV with ints
-    def test_ridge_cv_int(self):
-        np.random.seed(0)
-        self._test_ridge_cv(np.random.randint(2, size=100))
-
-    # RidgeCV with floats
-    def test_ridge_cv_float(self):
-        np.random.seed(0)
-        self._test_ridge_cv(np.random.rand(100))
-
-    # LogisticRegressionCV test function to be parameterized
-    def _test_logistic_regression_cv(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
-        if num_classes > 2:
-            model = LogisticRegressionCV(solver=solver, multi_class=multi_class, fit_intercept=True)
-        else:
-            model = LogisticRegressionCV(solver="liblinear", fit_intercept=True)
-
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(num_classes, size=100) + labels_shift
-
-        model.fit(X, y)
-        torch_model = hummingbird.ml.convert(model, "torch")
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # LogisticRegressionCV with 2 classes
-    def test_logistic_regression_cv_bi(self):
-        self._test_logistic_regression_cv(2)
-
-    # LogisticRegressionCV with 3 classes
-    def test_logistic_regression_cv_multi(self):
-        self._test_logistic_regression_cv(3)
-
-    # LogisticRegressionCV with shifted classes
-    def test_logistic_regression_cv_shifted_classes(self):
-        self._test_logistic_regression_cv(3, labels_shift=2)
-
-    # LogisticRegressionCV with multi+ovr
-    def test_logistic_regression_cv_multi_ovr(self):
-        self._test_logistic_regression_cv(3, multi_class="ovr")
-
-    # LogisticRegressionCV with multi+multinomial
-    def test_logistic_regression_cv_multi_multin(self):
-        warnings.filterwarnings("ignore")
-        # this will not converge due to small test size
-        self._test_logistic_regression_cv(3, multi_class="multinomial", solver="sag")
-
-    # SGDClassifier test function to be parameterized
-    def _test_sgd_classifier(self, num_classes):
+    # # LogisticRegression test function to be parameterized
+    # def _test_logistic_regression(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
+    #     if num_classes > 2:
+    #         model = LogisticRegression(solver=solver, multi_class=multi_class, fit_intercept=True)
+    #     else:
+    #         model = LogisticRegression(solver="liblinear", fit_intercept=True)
+
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(num_classes, size=100) + labels_shift
+
+    #     model.fit(X, y)
+
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # # LogisticRegression binary
+    # def test_logistic_regression_bi(self):
+    #     self._test_logistic_regression(2)
+
+    # # LogisticRegression multiclass with auto
+    # def test_logistic_regression_multi_auto(self):
+    #     self._test_logistic_regression(3)
+
+    # # LogisticRegression with class labels shifted
+    # def test_logistic_regression_shifted_classes(self):
+    #     self._test_logistic_regression(3, labels_shift=2)
+
+    # # LogisticRegression with multi+ovr
+    # def test_logistic_regression_multi_ovr(self):
+    #     self._test_logistic_regression(3, multi_class="ovr")
+
+    # # LogisticRegression with multi+multinomial+sag
+    # def test_logistic_regression_multi_multin_sag(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression(3, multi_class="multinomial", solver="sag")
+
+    # # LogisticRegression binary lbfgs
+    # def test_logistic_regression_bi_lbfgs(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression(2, solver="lbfgs")
+
+    # # LogisticRegression with multi+lbfgs
+    # def test_logistic_regression_multi_lbfgs(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression(3, solver="lbfgs")
+
+    # # LogisticRegression with multi+multinomial+lbfgs
+    # def test_logistic_regression_multi_multin_lbfgs(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression(3, multi_class="multinomial", solver="lbfgs")
+
+    # # LogisticRegression with multi+ovr+lbfgs
+    # def test_logistic_regression_multi_ovr_lbfgs(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression(3, multi_class="ovr", solver="lbfgs")
+
+    # # LinearRegression test function to be parameterized
+    # def _test_linear_regression(self, y_input):
+    #     model = LinearRegression()
+
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = y_input
+
+    #     model.fit(X, y)
+
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # # LinearRegression with ints
+    # def test_linear_regression_int(self):
+    #     np.random.seed(0)
+    #     self._test_linear_regression(np.random.randint(2, size=100))
+
+    # # LinearRegression with floats
+    # def test_linear_regression_float(self):
+    #     np.random.seed(0)
+    #     self._test_linear_regression(np.random.rand(100))
+
+    # # RidgeCV test function to be parameterized
+    # def _test_ridge_cv(self, y_input):
+    #     model = RidgeCV()
+
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = y_input
+
+    #     model.fit(X, y)
+
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # # RidgeCV with ints
+    # def test_ridge_cv_int(self):
+    #     np.random.seed(0)
+    #     self._test_ridge_cv(np.random.randint(2, size=100))
+
+    # # RidgeCV with floats
+    # def test_ridge_cv_float(self):
+    #     np.random.seed(0)
+    #     self._test_ridge_cv(np.random.rand(100))
+
+    # # LogisticRegressionCV test function to be parameterized
+    # def _test_logistic_regression_cv(self, num_classes, solver="liblinear", multi_class="auto", labels_shift=0):
+    #     if num_classes > 2:
+    #         model = LogisticRegressionCV(solver=solver, multi_class=multi_class, fit_intercept=True)
+    #     else:
+    #         model = LogisticRegressionCV(solver="liblinear", fit_intercept=True)
+
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(num_classes, size=100) + labels_shift
+
+    #     model.fit(X, y)
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # # LogisticRegressionCV with 2 classes
+    # def test_logistic_regression_cv_bi(self):
+    #     self._test_logistic_regression_cv(2)
+
+    # # LogisticRegressionCV with 3 classes
+    # def test_logistic_regression_cv_multi(self):
+    #     self._test_logistic_regression_cv(3)
+
+    # # LogisticRegressionCV with shifted classes
+    # def test_logistic_regression_cv_shifted_classes(self):
+    #     self._test_logistic_regression_cv(3, labels_shift=2)
+
+    # # LogisticRegressionCV with multi+ovr
+    # def test_logistic_regression_cv_multi_ovr(self):
+    #     self._test_logistic_regression_cv(3, multi_class="ovr")
+
+    # # LogisticRegressionCV with multi+multinomial
+    # def test_logistic_regression_cv_multi_multin(self):
+    #     warnings.filterwarnings("ignore")
+    #     # this will not converge due to small test size
+    #     self._test_logistic_regression_cv(3, multi_class="multinomial", solver="sag")
+
+    # # SGDClassifier test function to be parameterized
+    # def _test_sgd_classifier(self, num_classes):
 
-        model = SGDClassifier(loss="log")
+    #     model = SGDClassifier(loss="log")
 
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(num_classes, size=100)
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(num_classes, size=100)
 
-        model.fit(X, y)
+    #     model.fit(X, y)
 
-        torch_model = hummingbird.ml.convert(model, "torch")
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict_proba(X), torch_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-    # SGDClassifier with 2 classes
-    def test_sgd_classifier_bi(self):
-        self._test_sgd_classifier(2)
-
-    # SGDClassifier with 3 classes
-    def test_sgd_classifier_multi(self):
-        self._test_sgd_classifier(3)
-
-    # SGDClassifier with modified huber loss
-    @unittest.skipIf(
-        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    )
-    def test_modified_huber(self):
-        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-        Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
-
-        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-        model.fit(X, Y)
-
-        # Use Hummingbird to convert the model to PyTorch
-        hb_model = hummingbird.ml.convert(model, "torch")
-
-        inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
-        np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
-
-    @unittest.skipIf(
-        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    )
-    def test_modified_huber2(self):
-        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-        Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
-
-        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-        model.fit(X, Y)
-
-        # Use Hummingbird to convert the model to PyTorch
-        hb_model = hummingbird.ml.convert(model, "torch")
-
-        np.testing.assert_allclose(model.predict_proba(X), hb_model.predict_proba(X), rtol=1e-6, atol=1e-6)
-
-    # SGDClassifier with modified huber loss multiclass
-    @unittest.skipIf(
-        LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
-    )
-    def test_modified_huber_multi(self):
-        X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
-        Y = np.array([0, 1, 1, 1, 2, 2, 2, 2])
-
-        model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
-        model.fit(X, Y)
-
-        # Use Hummingbird to convert the model to PyTorch
-        hb_model = hummingbird.ml.convert(model, "torch")
-
-        inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
-        np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
-
-    # Failure sases
-    def test_sklearn_linear_model_raises_wrong_type(self):
-        warnings.filterwarnings("ignore")
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(3, size=100).astype(np.float32)  # y must be int, not float, should error
-        model = SGDClassifier().fit(X, y)
-        self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "torch")
-
-    # Float 64 data tests
-    def test_float64_linear_regression(self):
-        model = LinearRegression()
-
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        y = np.random.randint(2, size=100)
-
-        model.fit(X, y)
-
-        torch_model = hummingbird.ml.convert(model, "torch")
-
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    def test_float64_sgd_classifier(self):
-
-        model = SGDClassifier(loss="log")
-
-        np.random.seed(0)
-        num_classes = 3
-        X = np.random.rand(100, 200)
-        y = np.random.randint(num_classes, size=100)
-
-        model.fit(X, y)
-
-        torch_model = hummingbird.ml.convert(model, "torch")
-        self.assertTrue(torch_model is not None)
-        np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
-
-    # Multioutput regression tests
-    def test_multioutput_linear_regression(self):
-        for n_targets in [1, 2, 7]:
-            model = LinearRegression()
-            X, y = datasets.make_regression(
-                n_samples=100, n_features=10, n_informative=5, n_targets=n_targets, random_state=2021
-            )
-            model.fit(X, y)
-
-            torch_model = hummingbird.ml.convert(model, "torch")
-            self.assertTrue(torch_model is not None)
-            np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-5, atol=1e-5)
-
-    # Test Torschscript backend.
-    def test_logistic_regression_ts(self):
-
+    # # SGDClassifier with 2 classes
+    # def test_sgd_classifier_bi(self):
+    #     self._test_sgd_classifier(2)
+
+    # # SGDClassifier with 3 classes
+    # def test_sgd_classifier_multi(self):
+    #     self._test_sgd_classifier(3)
+
+    # # SGDClassifier with modified huber loss
+    # @unittest.skipIf(
+    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    # )
+    # def test_modified_huber(self):
+    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+    #     Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
+
+    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+    #     model.fit(X, Y)
+
+    #     # Use Hummingbird to convert the model to PyTorch
+    #     hb_model = hummingbird.ml.convert(model, "torch")
+
+    #     inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
+    #     np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
+
+    # @unittest.skipIf(
+    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    # )
+    # def test_modified_huber2(self):
+    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+    #     Y = np.array([1, 1, 1, 1, 2, 2, 2, 2])
+
+    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+    #     model.fit(X, Y)
+
+    #     # Use Hummingbird to convert the model to PyTorch
+    #     hb_model = hummingbird.ml.convert(model, "torch")
+
+    #     np.testing.assert_allclose(model.predict_proba(X), hb_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+
+    # # SGDClassifier with modified huber loss multiclass
+    # @unittest.skipIf(
+    #     LooseVersion(torch.__version__) < LooseVersion("1.6.0"), reason="Modified Huber loss test requires torch >= 1.6.0"
+    # )
+    # def test_modified_huber_multi(self):
+    #     X = np.array([[-0.5, -1], [-1, -1], [-0.1, -0.1], [0.1, -0.2], [0.5, 1], [1, 1], [0.1, 0.1], [-0.1, 0.2]])
+    #     Y = np.array([0, 1, 1, 1, 2, 2, 2, 2])
+
+    #     model = SGDClassifier(loss="modified_huber", max_iter=1000, tol=1e-3)
+    #     model.fit(X, Y)
+
+    #     # Use Hummingbird to convert the model to PyTorch
+    #     hb_model = hummingbird.ml.convert(model, "torch")
+
+    #     inputs = [[-1, -1], [1, 1], [-0.2, 0.1], [0.2, -0.1]]
+    #     np.testing.assert_allclose(model.predict_proba(inputs), hb_model.predict_proba(inputs), rtol=1e-6, atol=1e-6)
+
+    # # Failure cases
+    # def test_sklearn_linear_model_raises_wrong_type(self):
+    #     warnings.filterwarnings("ignore")
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(3, size=100).astype(np.float32)  # y must be int, not float, should error
+    #     model = SGDClassifier().fit(X, y)
+    #     self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "torch")
+
+    # # Float 64 data tests
+    # def test_float64_linear_regression(self):
+    #     model = LinearRegression()
+
+    #     np.random.seed(0)
+    #     X = np.random.rand(100, 200)
+    #     y = np.random.randint(2, size=100)
+
+    #     model.fit(X, y)
+
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # def test_float64_sgd_classifier(self):
+
+    #     model = SGDClassifier(loss="log")
+
+    #     np.random.seed(0)
+    #     num_classes = 3
+    #     X = np.random.rand(100, 200)
+    #     y = np.random.randint(num_classes, size=100)
+
+    #     model.fit(X, y)
+
+    #     torch_model = hummingbird.ml.convert(model, "torch")
+    #     self.assertTrue(torch_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-6, atol=1e-6)
+
+    # # Multioutput regression tests
+    # def test_multioutput_linear_regression(self):
+    #     for n_targets in [1, 2, 7]:
+    #         model = LinearRegression()
+    #         X, y = datasets.make_regression(
+    #             n_samples=100, n_features=10, n_informative=5, n_targets=n_targets, random_state=2021
+    #         )
+    #         model.fit(X, y)
+
+    #         torch_model = hummingbird.ml.convert(model, "torch")
+    #         self.assertTrue(torch_model is not None)
+    #         np.testing.assert_allclose(model.predict(X), torch_model.predict(X), rtol=1e-5, atol=1e-5)
+
+    # Test Pandas input
+    @unittest.skipIf(not pandas_installed(), reason="Test requires pandas installed")
+    def test_logistic_regression_pandas(self):
         model = LogisticRegression(solver="liblinear")
 
         data = datasets.load_iris()
-        X, y = data.data, data.target
+        X, y = data.data[:, :3], data.target
         X = X.astype(np.float32)
+        X_train = pandas.DataFrame(X, columns=["vA", "vB", "vC"])
+        X_train["vcat"] = X_train["vA"].apply(lambda x: 1 if x > 0.5 else 2)
+        X_train["vcat2"] = X_train["vB"].apply(lambda x: 3 if x > 0.5 else 4)
+        y_train = y % 2
 
-        model.fit(X, y)
+        model.fit(X_train, y_train)
 
-        ts_model = hummingbird.ml.convert(model, "torch.jit", X)
-        self.assertTrue(ts_model is not None)
-        np.testing.assert_allclose(model.predict(X), ts_model.predict(X), rtol=1e-6, atol=1e-6)
-        np.testing.assert_allclose(model.predict_proba(X), ts_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+        hb_model = hummingbird.ml.convert(model, "torch")
+        self.assertTrue(hb_model is not None)
+        np.testing.assert_allclose(model.predict(X_train), hb_model.predict(X_train), rtol=1e-6, atol=1e-6)
+        np.testing.assert_allclose(model.predict_proba(X_train), hb_model.predict_proba(X_train), rtol=1e-6, atol=1e-6)
 
-    # Test TVM backends.
-    @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
-    def test_sgd_classifier_tvm(self):
+    # # Test Torschscript backend.
+    # def test_logistic_regression_ts(self):
 
-        model = SGDClassifier(loss="log")
+    #     model = LogisticRegression(solver="liblinear")
 
-        np.random.seed(0)
-        num_classes = 3
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(num_classes, size=100)
+    #     data = datasets.load_iris()
+    #     X, y = data.data, data.target
+    #     X = X.astype(np.float32)
 
-        model.fit(X, y)
+    #     model.fit(X, y)
 
-        tvm_model = hummingbird.ml.convert(model, "tvm", X)
-        self.assertTrue(tvm_model is not None)
-        np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-6)
-        np.testing.assert_allclose(model.predict_proba(X), tvm_model.predict_proba(X), rtol=1e-6, atol=1e-6)
+    #     ts_model = hummingbird.ml.convert(model, "torch.jit", X)
+    #     self.assertTrue(ts_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), ts_model.predict(X), rtol=1e-6, atol=1e-6)
+    #     np.testing.assert_allclose(model.predict_proba(X), ts_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-    @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
-    def test_lr_tvm(self):
+    # # Test TVM backends.
+    # @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
+    # def test_sgd_classifier_tvm(self):
 
-        model = LinearRegression()
+    #     model = SGDClassifier(loss="log")
 
-        np.random.seed(0)
-        num_classes = 1000
-        X = np.random.rand(100, 200)
-        X = np.array(X, dtype=np.float32)
-        y = np.random.randint(num_classes, size=100)
+    #     np.random.seed(0)
+    #     num_classes = 3
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(num_classes, size=100)
 
-        model.fit(X, y)
+    #     model.fit(X, y)
 
-        tvm_model = hummingbird.ml.convert(model, "tvm", X, extra_config={constants.TVM_MAX_FUSE_DEPTH: 30})
-        self.assertTrue(tvm_model is not None)
+    #     tvm_model = hummingbird.ml.convert(model, "tvm", X)
+    #     self.assertTrue(tvm_model is not None)
+    #     np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-6)
+    #     np.testing.assert_allclose(model.predict_proba(X), tvm_model.predict_proba(X), rtol=1e-6, atol=1e-6)
 
-        np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-3)
+    # @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
+    # def test_lr_tvm(self):
+
+    #     model = LinearRegression()
+
+    #     np.random.seed(0)
+    #     num_classes = 1000
+    #     X = np.random.rand(100, 200)
+    #     X = np.array(X, dtype=np.float32)
+    #     y = np.random.randint(num_classes, size=100)
+
+    #     model.fit(X, y)
+
+    #     tvm_model = hummingbird.ml.convert(model, "tvm", X, extra_config={constants.TVM_MAX_FUSE_DEPTH: 30})
+    #     self.assertTrue(tvm_model is not None)
+
+    #     np.testing.assert_allclose(model.predict(X), tvm_model.predict(X), rtol=1e-6, atol=1e-3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We recently got a couple of issues (#482, #481) related to the fact that by default is no `test_input` is passed to `convert`, we expect a `numpy array` as input. This PR fixes this and now also `pandas dataframes` can be passed.