### PR TITLE
Use pickle instead of dill for pytorch models

### DIFF
--- a/hummingbird/ml/containers/sklearn/onnx_containers.py
+++ b/hummingbird/ml/containers/sklearn/onnx_containers.py
@@ -8,7 +8,7 @@
 ONNX output containers for the sklearn API are listed here.
 """
 
-import dill
+import pickle
 import os
 import numpy as np
 import shutil
@@ -80,7 +80,7 @@ class ONNXSklearnContainer(SklearnContainer):
 
         # Save the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "wb") as file:
-            dill.dump(self, file)
+            pickle.dump(self, file)
 
         # Zip the dir.
         shutil.make_archive(location, "zip", location)
@@ -131,7 +131,7 @@ class ONNXSklearnContainer(SklearnContainer):
 
         # Load the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "rb") as file:
-            container = dill.load(file)
+            container = pickle.load(file)
         assert container is not None, "Failed to load the model container."
 
         # Setup the container.

--- a/hummingbird/ml/containers/sklearn/pytorch_containers.py
+++ b/hummingbird/ml/containers/sklearn/pytorch_containers.py
@@ -8,7 +8,7 @@
 Pytorch and TorchScript output containers for the sklearn API are listed here.
 """
 
-import dill
+import pickle
 import os
 import numpy as np
 import shutil
@@ -67,7 +67,7 @@ class PyTorchSklearnContainer(SklearnContainer):
 
             # Save the container.
             with open(os.path.join(location, "container.pkl"), "wb") as file:
-                dill.dump(self, file)
+                pickle.dump(self, file)
 
             self._model = model
         elif "Executor" in str(type(self.model)):
@@ -78,7 +78,7 @@ class PyTorchSklearnContainer(SklearnContainer):
 
             # Save the actual model plus the container
             with open(os.path.join(location, constants.SAVE_LOAD_TORCH_JIT_PATH), "wb") as file:
-                dill.dump(self, file)
+                pickle.dump(self, file)
         else:
             raise RuntimeError("Model type {} not recognized.".format(type(self.model)))
 
@@ -121,12 +121,12 @@ class PyTorchSklearnContainer(SklearnContainer):
             # This is a torch.jit model
             model = torch.jit.load(os.path.join(location, constants.SAVE_LOAD_TORCH_JIT_PATH))
             with open(os.path.join(location, "container.pkl"), "rb") as file:
-                container = dill.load(file)
+                container = pickle.load(file)
             container._model = model
         elif model_type == "torch":
             # This is a pytorch  model
             with open(os.path.join(location, constants.SAVE_LOAD_TORCH_JIT_PATH), "rb") as file:
-                container = dill.load(file)
+                container = pickle.load(file)
         else:
             raise RuntimeError("Model type {} not recognized".format(model_type))
 

--- a/hummingbird/ml/containers/sklearn/pytorch_containers.py
+++ b/hummingbird/ml/containers/sklearn/pytorch_containers.py
@@ -8,7 +8,6 @@
 Pytorch and TorchScript output containers for the sklearn API are listed here.
 """
 
-import dill
 import pickle
 import os
 import numpy as np
@@ -68,7 +67,7 @@ class PyTorchSklearnContainer(SklearnContainer):
 
             # Save the container.
             with open(os.path.join(location, "container.pkl"), "wb") as file:
-                dill.dump(self, file)
+                pickle.dump(self, file)
 
             self._model = model
         elif "Executor" in str(type(self.model)):
@@ -122,7 +121,7 @@ class PyTorchSklearnContainer(SklearnContainer):
             # This is a torch.jit model
             model = torch.jit.load(os.path.join(location, constants.SAVE_LOAD_TORCH_JIT_PATH))
             with open(os.path.join(location, "container.pkl"), "rb") as file:
-                container = dill.load(file)
+                container = pickle.load(file)
             container._model = model
         elif model_type == "torch":
             # This is a pytorch  model

--- a/hummingbird/ml/containers/sklearn/pytorch_containers.py
+++ b/hummingbird/ml/containers/sklearn/pytorch_containers.py
@@ -8,6 +8,7 @@
 Pytorch and TorchScript output containers for the sklearn API are listed here.
 """
 
+import dill
 import pickle
 import os
 import numpy as np
@@ -67,7 +68,7 @@ class PyTorchSklearnContainer(SklearnContainer):
 
             # Save the container.
             with open(os.path.join(location, "container.pkl"), "wb") as file:
-                pickle.dump(self, file)
+                dill.dump(self, file)
 
             self._model = model
         elif "Executor" in str(type(self.model)):
@@ -121,7 +122,7 @@ class PyTorchSklearnContainer(SklearnContainer):
             # This is a torch.jit model
             model = torch.jit.load(os.path.join(location, constants.SAVE_LOAD_TORCH_JIT_PATH))
             with open(os.path.join(location, "container.pkl"), "rb") as file:
-                container = pickle.load(file)
+                container = dill.load(file)
             container._model = model
         elif model_type == "torch":
             # This is a pytorch  model

--- a/hummingbird/ml/containers/sklearn/tvm_containers.py
+++ b/hummingbird/ml/containers/sklearn/tvm_containers.py
@@ -8,7 +8,7 @@
 TVM output containers for the sklearn API are listed here.
 """
 
-import dill
+import pickle
 import os
 import numpy as np
 import shutil
@@ -96,7 +96,7 @@ class TVMSklearnContainer(SklearnContainer):
 
         # Save the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "wb") as file:
-            dill.dump(self, file)
+            pickle.dump(self, file)
 
         # Zip the dir.
         shutil.make_archive(location, "zip", location)
@@ -164,7 +164,7 @@ class TVMSklearnContainer(SklearnContainer):
 
         # Load the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "rb") as file:
-            container = dill.load(file)
+            container = pickle.load(file)
         assert container is not None, "Failed to load the model container."
 
         # Setup the container.

--- a/hummingbird/ml/containers/sklearn/tvm_containers.py
+++ b/hummingbird/ml/containers/sklearn/tvm_containers.py
@@ -8,7 +8,7 @@
 TVM output containers for the sklearn API are listed here.
 """
 
-import pickle
+import dill
 import os
 import numpy as np
 import shutil
@@ -96,7 +96,7 @@ class TVMSklearnContainer(SklearnContainer):
 
         # Save the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "wb") as file:
-            pickle.dump(self, file)
+            dill.dump(self, file)
 
         # Zip the dir.
         shutil.make_archive(location, "zip", location)
@@ -164,7 +164,7 @@ class TVMSklearnContainer(SklearnContainer):
 
         # Load the container.
         with open(os.path.join(location, constants.SAVE_LOAD_CONTAINER_PATH), "rb") as file:
-            container = pickle.load(file)
+            container = dill.load(file)
         assert container is not None, "Failed to load the model container."
 
         # Setup the container.

--- a/hummingbird/ml/operator_converters/_tree_implementations.py
+++ b/hummingbird/ml/operator_converters/_tree_implementations.py
@@ -14,6 +14,7 @@ import torch
 
 from . import constants
 from ._physical_operator import PhysicalOperator
+from . import _tree_commons
 
 
 class TreeImpl(Enum):
@@ -504,7 +505,7 @@ class GEMMGBDTImpl(GEMMTreeImpl):
         super(GEMMGBDTImpl, self).__init__(logical_operator, tree_parameters, n_features, classes, 1, extra_config)
 
         self.n_gbdt_classes = 1
-        self.post_transform = lambda x: x
+        self.post_transform = _tree_commons.PostTransform()
 
         if constants.POST_TRANSFORM in extra_config:
             self.post_transform = extra_config[constants.POST_TRANSFORM]
@@ -539,7 +540,7 @@ class TreeTraversalGBDTImpl(TreeTraversalTreeImpl):
         )
 
         self.n_gbdt_classes = 1
-        self.post_transform = lambda x: x
+        self.post_transform = _tree_commons.PostTransform()
 
         if constants.POST_TRANSFORM in extra_config:
             self.post_transform = extra_config[constants.POST_TRANSFORM]

--- a/hummingbird/ml/operator_converters/_tree_implementations.py
+++ b/hummingbird/ml/operator_converters/_tree_implementations.py
@@ -575,7 +575,7 @@ class PerfectTreeTraversalGBDTImpl(PerfectTreeTraversalTreeImpl):
         )
 
         self.n_gbdt_classes = 1
-        self.post_transform = lambda x: x
+        self.post_transform = _tree_commons.PostTransform()
 
         if constants.POST_TRANSFORM in extra_config:
             self.post_transform = extra_config[constants.POST_TRANSFORM]

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "tests": ["flake8", "pytest", "coverage", "pre-commit"],
-        "sparkml": ["pyspark>=2.4.4"],
+        "sparkml": ["pyspark>=2.4.4", "pyarrow>1.0"],
         "onnx": onnx_requires,
         "extra": extra_requires,
         "benchmark": onnx_requires + extra_requires + ["memory-profiler", "psutil"],

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -558,54 +558,6 @@ class TestBackends(unittest.TestCase):
         # Broadcast the model returns an error.
         self.assertRaises(pickle.PickleError, spark.sparkContext.broadcast, hb_model)
 
-    @unittest.skipIf(
-        not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3"
-    )
-    def test_udf_torch_jit_spark_file(self):
-        import dill
-        import torch.jit
-
-        X, y = load_iris(return_X_y=True)
-        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
-        spark_df = sql_context.createDataFrame(pd.DataFrame(data=X_train))
-        sql_context.registerDataFrameAsTable(spark_df, "IRIS")
-
-        model = GradientBoostingClassifier(n_estimators=10)
-        model.fit(X_train, y_train)
-
-        hb_model = hummingbird.ml.convert(model, "torch.jit", X_test)
-
-        # Save the file locally.
-        if os.path.exists("deployed_model.zip"):
-            os.remove("deployed_model.zip")
-        torch.jit.save(hb_model.model, "deployed_model.zip")
-        hb_model._model = None
-
-        # Share the model using spark file and broadcast the container.
-        spark.sparkContext.addFile("deployed_model.zip")
-        broadcasted_container = spark.sparkContext.broadcast(hb_model)
-
-        # UDF definition.
-        @pandas_udf("long")
-        def udf_hb_predict(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
-            location = SparkFiles.get("deployed_model.zip")
-            torch_model = torch.jit.load(location)
-            container = broadcasted_container.value
-            container._model = torch_model
-            model = container
-            for args in iterator:
-                data_unmangled = pd.concat([feature for feature in args], axis=1)
-                predictions = model.predict(data_unmangled.values)
-                yield pd.Series(np.array(predictions))
-
-        # Register the UDF.
-        sql_context.udf.register("PREDICT", udf_hb_predict)
-
-        # Run the query.
-        sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
-
-        os.remove("deployed_model.zip")
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -508,7 +508,7 @@ class TestBackends(unittest.TestCase):
 
     # Test Spark UDF
     @unittest.skipIf(
-        os.name != "nt" and not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
         reason="UDF Test requires spark >= 3",
     )
     def test_udf_torch(self):
@@ -541,7 +541,7 @@ class TestBackends(unittest.TestCase):
         sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
 
     @unittest.skipIf(
-        os.name != "nt" and not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
         reason="UDF Test requires spark >= 3",
     )
     def test_udf_torch_jit_broadcast(self):
@@ -561,7 +561,7 @@ class TestBackends(unittest.TestCase):
         self.assertRaises(pickle.PickleError, spark.sparkContext.broadcast, hb_model)
 
     @unittest.skipIf(
-        os.name != "nt" and not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
         reason="UDF Test requires spark >= 3",
     )
     def test_udf_torch_jit_spark_file(self):

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -507,8 +507,9 @@ class TestBackends(unittest.TestCase):
         self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "onnx")
 
     # Test Spark UDF
-    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
-    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    @unittest.skipIf(
+        not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3"
+    )
     def test_udf_torch(self):
         X, y = load_iris(return_X_y=True)
         X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
@@ -538,8 +539,9 @@ class TestBackends(unittest.TestCase):
         # Run the query.
         sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
 
-    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
-    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    @unittest.skipIf(
+        not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3"
+    )
     def test_udf_torch_jit_broadcast(self):
         import pickle
 
@@ -556,8 +558,9 @@ class TestBackends(unittest.TestCase):
         # Broadcast the model returns an error.
         self.assertRaises(pickle.PickleError, spark.sparkContext.broadcast, hb_model)
 
-    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
-    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    @unittest.skipIf(
+        not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3"
+    )
     def test_udf_torch_jit_spark_file(self):
         import dill
         import torch.jit

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -6,10 +6,14 @@ import warnings
 import os
 import shutil
 import numpy as np
+from typing import Iterator
+from distutils.version import LooseVersion
 
 from sklearn.ensemble import GradientBoostingClassifier
 from sklearn.preprocessing import StandardScaler
 from sklearn.preprocessing import OneHotEncoder
+from sklearn.datasets import load_iris
+from sklearn.model_selection import train_test_split
 from onnxconverter_common.data_types import (
     FloatTensorType,
     DoubleTensorType,
@@ -19,11 +23,29 @@ from onnxconverter_common.data_types import (
 )
 
 import hummingbird.ml
-from hummingbird.ml._utils import onnx_ml_tools_installed, onnx_runtime_installed, tvm_installed
+from hummingbird.ml._utils import (
+    onnx_ml_tools_installed,
+    onnx_runtime_installed,
+    tvm_installed,
+    sparkml_installed,
+    pandas_installed,
+)
 from hummingbird.ml.exceptions import MissingBackend
 
 if onnx_ml_tools_installed():
     from onnxmltools.convert import convert_sklearn
+
+if sparkml_installed():
+    import pyspark
+    from pyspark import SparkFiles
+    from pyspark.sql import SparkSession, SQLContext
+    from pyspark.sql.functions import pandas_udf, col, expr
+
+    spark = SparkSession.builder.master("local[*]").config("spark.driver.bindAddress", "127.0.0.1").getOrCreate()
+    sql_context = SQLContext(spark)
+
+if pandas_installed():
+    import pandas as pd
 
 
 class TestBackends(unittest.TestCase):
@@ -483,6 +505,103 @@ class TestBackends(unittest.TestCase):
         model.fit(X, y)
 
         self.assertRaises(RuntimeError, hummingbird.ml.convert, model, "onnx")
+
+    # Test Spark UDF
+    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
+    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    def test_udf_torch(self):
+        X, y = load_iris(return_X_y=True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
+        spark_df = sql_context.createDataFrame(pd.DataFrame(data=X_train))
+        sql_context.registerDataFrameAsTable(spark_df, "IRIS")
+
+        model = GradientBoostingClassifier(n_estimators=10)
+        model.fit(X_train, y_train)
+
+        hb_model = hummingbird.ml.convert(model, "torch")
+
+        # Broadcast the model.
+        broadcasted_model = spark.sparkContext.broadcast(hb_model)
+
+        # UDF definition.
+        @pandas_udf("long")
+        def udf_hb_predict(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
+            model = broadcasted_model.value
+            for args in iterator:
+                data_unmangled = pd.concat([feature for feature in args], axis=1)
+                predictions = model.predict(data_unmangled)
+                yield pd.Series(np.array(predictions))
+
+        # Register the UDF.
+        sql_context.udf.register("PREDICT", udf_hb_predict)
+
+        # Run the query.
+        sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
+
+    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
+    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    def test_udf_torch_jit_broadcast(self):
+        import pickle
+
+        X, y = load_iris(return_X_y=True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
+        spark_df = sql_context.createDataFrame(pd.DataFrame(data=X_train))
+        sql_context.registerDataFrameAsTable(spark_df, "IRIS")
+
+        model = GradientBoostingClassifier(n_estimators=10)
+        model.fit(X_train, y_train)
+
+        hb_model = hummingbird.ml.convert(model, "torch.jit", X_test)
+
+        # Broadcast the model returns an error.
+        self.assertRaises(pickle.PickleError, spark.sparkContext.broadcast, hb_model)
+
+    @unittest.skipIf(not sparkml_installed(), reason="UDF test requires Spark installed")
+    @unittest.skipIf(LooseVersion(pyspark.__version__) < LooseVersion("3"), reason="UDF Test requires spark >= 3")
+    def test_udf_torch_jit_spark_file(self):
+        import dill
+        import torch.jit
+
+        X, y = load_iris(return_X_y=True)
+        X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=77, test_size=0.2,)
+        spark_df = sql_context.createDataFrame(pd.DataFrame(data=X_train))
+        sql_context.registerDataFrameAsTable(spark_df, "IRIS")
+
+        model = GradientBoostingClassifier(n_estimators=10)
+        model.fit(X_train, y_train)
+
+        hb_model = hummingbird.ml.convert(model, "torch.jit", X_test)
+
+        # Save the file locally.
+        if os.path.exists("deployed_model.zip"):
+            os.remove("deployed_model.zip")
+        torch.jit.save(hb_model.model, "deployed_model.zip")
+        hb_model._model = None
+
+        # Share the model using spark file and broadcast the container.
+        spark.sparkContext.addFile("deployed_model.zip")
+        broadcasted_container = spark.sparkContext.broadcast(hb_model)
+
+        # UDF definition.
+        @pandas_udf("long")
+        def udf_hb_predict(iterator: Iterator[pd.Series]) -> Iterator[pd.Series]:
+            location = SparkFiles.get("deployed_model.zip")
+            torch_model = torch.jit.load(location)
+            container = broadcasted_container.value
+            container._model = torch_model
+            model = container
+            for args in iterator:
+                data_unmangled = pd.concat([feature for feature in args], axis=1)
+                predictions = model.predict(data_unmangled.values)
+                yield pd.Series(np.array(predictions))
+
+        # Register the UDF.
+        sql_context.udf.register("PREDICT", udf_hb_predict)
+
+        # Run the query.
+        sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
+
+        os.remove("deployed_model.zip")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
In this PR I removed few lambdas so that we can use pickle instead of dill to save pytorch models. This allows to use Hummingbird models where pickle is used for serialization (e.g., spark UDF). I added few tests on spark to prove this.