### PR TITLE
macOS issue with  python3.6 in pipeline

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         pip install .[extra,onnx,sparkml]
         pip install pandas
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       # TVM takes forever, we try to cache it.
       if: ${{ matrix.os != 'windows-2019' }}
       id: cache

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -60,7 +60,7 @@ jobs:
     - name: If mac, install libomp to facilitate lgbm install
       if: matrix.os == 'macos-10.15'
       run: |
-        brew install libomp==11.1.0
+        brew install libomp@11.1.0
         export CC=/usr/bin/clang
         export CXX=/usr/bin/clang++
         export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -60,7 +60,7 @@ jobs:
     - name: If mac, install libomp to facilitate lgbm install
       if: matrix.os == 'macos-10.15'
       run: |
-        brew install libomp
+        brew install libomp==11.1.0
         export CC=/usr/bin/clang
         export CXX=/usr/bin/clang++
         export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -60,7 +60,8 @@ jobs:
     - name: If mac, install libomp to facilitate lgbm install
       if: matrix.os == 'macos-10.15'
       run: |
-        brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/b090d52f326f6ff1529bf650b626c07d6b43ab1b/Formula/libomp.rb
+        wget https://raw.githubusercontent.com/Homebrew/homebrew-core/fb8323f2b170bd4ae97e1bac9bf3e2983af3fdb0/Formula/libomp.rb
+        brew install ./libomp.rb
         export CC=/usr/bin/clang
         export CXX=/usr/bin/clang++
         export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -72,7 +72,7 @@ jobs:
       run: |
         pip install .[extra,onnx,sparkml]
         pip install pandas
-    - uses: actions/cache@v2
+    - uses: actions/cache@v1
       # TVM takes forever, we try to cache it.
       if: ${{ matrix.os != 'windows-2019' }}
       id: cache

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -60,7 +60,7 @@ jobs:
     - name: If mac, install libomp to facilitate lgbm install
       if: matrix.os == 'macos-10.15'
       run: |
-        brew install libomp@11.1.0
+        brew update && brew install https://raw.githubusercontent.com/Homebrew/homebrew-core/b090d52f326f6ff1529bf650b626c07d6b43ab1b/Formula/libomp.rb
         export CC=/usr/bin/clang
         export CXX=/usr/bin/clang++
         export CPPFLAGS="$CPPFLAGS -Xpreprocessor -fopenmp"

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -71,7 +71,7 @@ jobs:
       run: |
         pip install .[extra,onnx,sparkml]
         pip install pandas
-    - uses: actions/cache@v1
+    - uses: actions/cache@v2
       # TVM takes forever, we try to cache it.
       if: ${{ matrix.os != 'windows-2019' }}
       id: cache


### PR DESCRIPTION
The pipeline surprise-broke today.  After a lot of troubleshooting, it seems it was due to `libomp` version change.  12.0.0 only works with python 3.8 it seems (3.6 and 3.7 broke).  

With some struggles, pinning this to an older (11.1.0) version of libomp. Hopefully there will be a better fix later.