### PR TITLE
Update LGBM references with scikit-learn in the sklearn_year_with_train.ipynb notebook

### DIFF
--- a/notebooks/sklearn_year_with_train.ipynb
+++ b/notebooks/sklearn_year_with_train.ipynb
@@ -359,7 +359,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Convert LGBM model to PyTorch"
+    "#### Convert scikit-learn model to PyTorch"
    ]
   },
   {
@@ -447,7 +447,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Convert LGBM model to TVM (CPU)"
+    "#### Convert scikit-learn model to TVM (CPU)"
    ]
   },
   {
@@ -489,7 +489,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Convert LBGM model to TVM (GPU)"
+    "#### Convert scikit-learn model to TVM (GPU)"
    ]
   },
   {


### PR DESCRIPTION
Corrected a typo where the `scikit-learn` models were mentioned as `LGBM` models.