### PR TITLE
Use `onnxmltools>=1.6.0,<=1.11.0` instead of `onnxmltools>=1.6.0`

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -74,6 +74,8 @@ jobs:
       run: |
         pip install .[extra,onnx,sparkml]
         pip install pandas
+    - name: pip list
+      run: pip list
     - uses: actions/cache@v1
       # TVM takes forever, we try to cache it.
       if: ${{ matrix.os != 'windows-2019' }}
@@ -126,6 +128,8 @@ jobs:
       working-directory: ../../../tvm/python
       run: |
         python setup.py install
+    - name: pip list
+      run: pip list
     # We don't run pytest for Linux py3.7 since we do coverage for that case.
     - name: Test with pytest
       if: ${{ matrix.python-version != '3.7' || matrix.os != 'ubuntu-18.04' }}

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -54,6 +54,7 @@ jobs:
       run: |
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
         pip install git+https://github.com/onnx/sklearn-onnx.git@9b551d8ecfd9f97ad8771909e34cfffea7b6e99d
+        pip install "scikit-learn>=0.21.3,<1.1.0"
     - name: Run basic tests without extra
       run: pytest
     - name: Coverage on basic tests without extra

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ install_requires = [
 ]
 onnx_requires = [
     "onnxruntime>=1.0.0",
-    "onnxmltools>=1.6.0",
+    "onnxmltools>=1.6.0,<=1.11.0",
     "skl2onnx>=1.7.0",
 ]
 extra_requires = [


### PR DESCRIPTION
`import onnxmltools` will fail with
`onnxconverter_common==1.8.1` & `onnxmltools==1.11.1`. The failure caused ONNX test skipping. 
In this PR, we'll use `onnxmltools>=1.6.0,<=1.11.0` instead of `onnxmltools>=1.6.0`.

Fix #589