### PR TITLE
Updating library versions

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -53,7 +53,7 @@ jobs:
     - name: Install basic dependencies
       run: |
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
-        pip install "scikit-learn>1.1.0"
+        pip install scikit-learn
     - name: Run basic tests without extra
       run: pytest
     - name: Coverage on basic tests without extra

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -54,7 +54,7 @@ jobs:
       run: |
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
         pip install git+https://github.com/onnx/sklearn-onnx.git@9b551d8ecfd9f97ad8771909e34cfffea7b6e99d
-        pip install "scikit-learn>=0.21.3,<1.1.0"
+        pip install "scikit-learn>1.1.0"
     - name: Run basic tests without extra
       run: pytest
     - name: Coverage on basic tests without extra

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-10.15, windows-2019]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -53,7 +53,6 @@ jobs:
     - name: Install basic dependencies
       run: |
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
-        pip install git+https://github.com/onnx/sklearn-onnx.git@9b551d8ecfd9f97ad8771909e34cfffea7b6e99d
         pip install "scikit-learn>1.1.0"
     - name: Run basic tests without extra
       run: pytest

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -53,7 +53,6 @@ jobs:
     - name: Install basic dependencies
       run: |
         pip install .[tests] -f https://download.pytorch.org/whl/torch_stable.html
-        pip install scikit-learn
     - name: Run basic tests without extra
       run: pytest
     - name: Coverage on basic tests without extra

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/hummingbird-ml.svg)](https://badge.fury.io/py/hummingbird-ml)
 [![](https://github.com/microsoft/hummingbird/workflows/Build/badge.svg?branch=main)](https://github.com/microsoft/hummingbird/actions)
-![](https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9-blue)
+![](https://img.shields.io/badge/python-3.8%20%7C%203.9-blue)
 [![coverage](https://codecov.io/gh/microsoft/hummingbird/branch/main/graph/badge.svg)](https://codecov.io/github/microsoft/hummingbird?branch=main)
 [![Gitter](https://badges.gitter.im/hummingbird-ml/community.svg)](https://gitter.im/hummingbird-ml/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Downloads](https://pepy.tech/badge/hummingbird-ml)](https://pepy.tech/project/hummingbird-ml)
@@ -64,7 +64,7 @@ _Thank you to [Chien Vu](https://www.linkedin.com/in/vumichien/) for contributin
 
 ## Installation
 
-Hummingbird was tested on Python >= 3.7 on Linux, Windows and MacOS machines.  (Python 3.6 is supported up to `hummingbird-ml==0.4.2`.)  It is recommended to use a virtual environment (See: [python3 venv doc](https://docs.python.org/3/tutorial/venv.html) or [Using Python environments in VS Code](https://code.visualstudio.com/docs/python/environments).)
+Hummingbird was tested on Python 3.8 and 3.9 on Linux, Windows and MacOS machines.  It is recommended to use a virtual environment (See: [python3 venv doc](https://docs.python.org/3/tutorial/venv.html) or [Using Python environments in VS Code](https://code.visualstudio.com/docs/python/environments).)
 
 Hummingbird requires PyTorch >= 1.6.0. Please go [here](https://pytorch.org/) for instructions on how to install PyTorch based on your platform and hardware.
 

--- a/hummingbird/ml/_executor.py
+++ b/hummingbird/ml/_executor.py
@@ -50,6 +50,8 @@ class Executor(torch.nn.Module, object):
                             map[i.raw_name] = i.full_name
                 if len(map) == len(names):
                     break
+            if map == {}:
+                return names
             for name in names:
                 new_names.append(map[name])
             return new_names

--- a/hummingbird/ml/_parse.py
+++ b/hummingbird/ml/_parse.py
@@ -601,6 +601,10 @@ def _parse_onnx_api(topology, model, inputs):
     initializers = [] if graph.initializer is None else [in_ for in_ in graph.initializer]
     node_list = LinkedNode.build_from_onnx(graph.node, [], inputs_names + [in_.name for in_ in initializers], output_names)
 
+    # Make sure the entire node_list isn't only 'Identity'
+    if all([x.op_type == 'Identity' for x in node_list]):
+        raise RuntimeError("ONNX model contained only Identity nodes {}.".format(node_list))
+
     # This a new node list but with some node been removed plus eventual variable renaming.
     new_node_list = _remove_zipmap(node_list)
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ install_requires = [
     "numpy>=1.15",
     "onnxconverter-common>=1.6.0",
     "scipy",
+    "scikit-learn",
     "torch>=1.4",
     "psutil",
     "dill",

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -542,34 +542,6 @@ class TestBackends(unittest.TestCase):
         hb_model = hummingbird.ml.convert(onnx_ml_model, "onnx")
         assert hb_model
 
-    # Test onnx 0 shape input
-    @unittest.skipIf(
-        not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test require ONNX, ORT and ONNXMLTOOLS"
-    )
-    def test_onnx_zero_shape_input(self):
-        warnings.filterwarnings("ignore")
-        max_depth = 10
-        num_classes = 2
-        if CastTransformer is None:
-            model = GradientBoostingClassifier(n_estimators=10, max_depth=max_depth)
-        else:
-            # newer version of sklearn-onnx
-            model = make_pipeline(
-                CastTransformer(dtype=np.float32), GradientBoostingClassifier(n_estimators=10, max_depth=max_depth)
-            )
-        np.random.seed(0)
-        X = np.random.rand(100, 200)
-        y = np.random.randint(num_classes, size=100)
-
-        model.fit(X, y)
-
-        # Create ONNX-ML model
-        onnx_ml_model = convert_sklearn(model, initial_types=[("input", DoubleTensorType([0, X.shape[1]]))], target_opset=11)
-
-        # Test onnx requires no test_data
-        hb_model = hummingbird.ml.convert(onnx_ml_model, "onnx")
-        assert hb_model
-
     # Test onnx no test_data, double input
     @unittest.skipIf(
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test require ONNX, ORT and ONNXMLTOOLS"

--- a/tests/test_onnxml_scaler_converter.py
+++ b/tests/test_onnxml_scaler_converter.py
@@ -20,7 +20,7 @@ if onnx_ml_tools_installed():
 
 
 class TestONNXScaler(unittest.TestCase):
-    def _test_scaler_converter(self, model, check_raise=False):
+    def _test_scaler_converter(self, model):
         warnings.filterwarnings("ignore")
         X = np.array([[0.0, 0.0, 3.0], [1.0, -1.0, 0.0], [0.0, 2.0, 1.0], [1.0, 0.0, -2.0]], dtype=np.float32)
         model.fit(X)
@@ -29,11 +29,6 @@ class TestONNXScaler(unittest.TestCase):
         onnx_ml_model = convert_sklearn(
             model, initial_types=[("float_input", FloatTensorType([None, X.shape[1]]))]
         )
-
-        # Having with_mean=False, with_std=False returns identity model in convert_sklearn
-        if check_raise:
-            self.assertRaises(RuntimeError, convert, onnx_ml_model, "onnx", X)
-            return
 
         # Create ONNX model by calling converter
         onnx_model = convert(onnx_ml_model, "onnx", X)
@@ -79,7 +74,7 @@ class TestONNXScaler(unittest.TestCase):
         model = StandardScaler(with_mean=False, with_std=False)
 
         # Expect that this raises an error due to unsuppoted model type
-        self._test_scaler_converter(model, check_raise=True)
+        self.assertRaises(RuntimeError, self._test_scaler_converter, model)
 
     # Test RobustScaler with with_centering=True
     @unittest.skipIf(

--- a/tests/test_onnxml_scaler_converter.py
+++ b/tests/test_onnxml_scaler_converter.py
@@ -65,17 +65,6 @@ class TestONNXScaler(unittest.TestCase):
         # Check that predicted values match
         np.testing.assert_allclose(onnx_ml_pred, onnx_pred, rtol=rtol, atol=atol)
 
-    # Test StandardScaler with_mean=False, with_std=False
-    @unittest.skipIf(
-        not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test requires ONNX, ORT and ONNXMLTOOLS"
-    )
-    def test_standard_scaler_onnx_ff(self, rtol=1e-06, atol=1e-06):
-        model = StandardScaler(with_mean=False, with_std=False)
-        onnx_ml_pred, onnx_pred = self._test_scaler_converter(model)
-
-        # Check that predicted values match
-        np.testing.assert_allclose(onnx_ml_pred, onnx_pred, rtol=rtol, atol=atol)
-
     # Test RobustScaler with with_centering=True
     @unittest.skipIf(
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test requires ONNX, ORT and ONNXMLTOOLS"


### PR DESCRIPTION
"scikit-learn requires: Python (>= 3.8)" [link](https://pypi.org/project/scikit-learn/)

Deprecating Python 3.7.  Removing the skl2onnx pin.
