### PR TITLE
Use `n_features_in_` instead of `n_features_`

### DIFF
--- a/hummingbird/ml/operator_converters/sklearn/decision_tree.py
+++ b/hummingbird/ml/operator_converters/sklearn/decision_tree.py
@@ -32,7 +32,7 @@ def convert_sklearn_random_forest_classifier(operator, device, extra_config):
 
     # Get tree information out of the model.
     tree_infos = operator.raw_operator.estimators_
-    n_features = operator.raw_operator.n_features_
+    n_features = operator.raw_operator.n_features_in_
     classes = operator.raw_operator.classes_.tolist()
 
     # For Sklearn Trees we need to know how many trees are there for normalization.
@@ -72,7 +72,7 @@ def convert_sklearn_random_forest_regressor(operator, device, extra_config):
 
     # Get tree information out of the operator.
     tree_infos = operator.raw_operator.estimators_
-    n_features = operator.raw_operator.n_features_
+    n_features = operator.raw_operator.n_features_in_
 
     # For Sklearn Trees we need to know how many trees are there for normalization.
     extra_config[constants.NUM_TREES] = len(tree_infos)

--- a/hummingbird/ml/operator_converters/sklearn/gbdt.py
+++ b/hummingbird/ml/operator_converters/sklearn/gbdt.py
@@ -18,7 +18,7 @@ from .._tree_commons import get_parameters_for_sklearn_common, get_parameters_fo
 
 def _get_n_features(model):
     try:
-        return model.n_features_
+        return model.n_features_in_
     except AttributeError:
         # HistGradientBoosting
         return model._n_features

--- a/hummingbird/ml/operator_converters/sklearn/iforest.py
+++ b/hummingbird/ml/operator_converters/sklearn/iforest.py
@@ -221,7 +221,7 @@ def convert_sklearn_isolation_forest(operator, device, extra_config):
     assert operator is not None, "Cannot convert None operator"
 
     tree_infos = operator.raw_operator.estimators_
-    n_features = operator.raw_operator.n_features_
+    n_features = operator.raw_operator.n_features_in_
     # Following constants will be passed in the tree implementation to normalize the anomaly score.
     extra_config[constants.OFFSET] = operator.raw_operator.offset_
     if hasattr(operator.raw_operator, "threshold_"):


### PR DESCRIPTION
`n_features_` attribute was deprecated in skl 1.0 and will be removed in 1.2.
In this PR, we'll use `n_features_in_` instead of `n_features_`.
