### PR TITLE
Upgrade prophet to v1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ extra_requires = [
     # The need each for these depends on which libraries you plan to convert from
     "xgboost>=0.90",
     "lightgbm>=2.2",
-    "prophet==1.0.1",
+    "prophet==1.1",
 ]
 setup(
     name="hummingbird-ml",


### PR DESCRIPTION
`prophet==1.0.1` depends on `pystan==2.19.1.1` which is no longer maintained and not compatible with Python 3.10. They removed the dependency in the [`prophet==1.1` release](https://github.com/facebook/prophet/releases/tag/v1.1).
In this PR, we bump to `prophet==1.1`.
Related to #586 