### PR TITLE
Fix deprecation warnings for sklearn/scipy

### DIFF
--- a/benchmarks/operators/train.py
+++ b/benchmarks/operators/train.py
@@ -157,7 +157,7 @@ class CreateLogisticRegressionCV(CreateModel):
 
 class CreateSGDClassifier(CreateModel):
     def fit(self, data, args):
-        self.model = SGDClassifier(loss="log")
+        self.model = SGDClassifier(loss="log_loss")
 
         with Timer() as t:
             self.model.fit(data.X_train, data.y_train)

--- a/hummingbird/ml/operator_converters/_sv_implementations.py
+++ b/hummingbird/ml/operator_converters/_sv_implementations.py
@@ -23,7 +23,7 @@ class SVC(PhysicalOperator, torch.nn.Module):
         self.degree = degree
         self.gamma = gamma
         self.regression = False
-        sv = sv.toarray() if type(sv) == scipy.sparse.csr.csr_matrix else sv
+        sv = sv.toarray() if type(sv) == scipy.sparse.csr_matrix else sv
         self.sv = torch.nn.Parameter(torch.from_numpy(sv).double(), requires_grad=False)
         self.sv_t = torch.nn.Parameter(torch.transpose(self.sv, 0, 1), requires_grad=False)
         self.sv_norm = torch.nn.Parameter(-self.gamma * (self.sv ** 2).sum(1).view(1, -1), requires_grad=False)

--- a/hummingbird/ml/operator_converters/sklearn/decomposition.py
+++ b/hummingbird/ml/operator_converters/sklearn/decomposition.py
@@ -55,10 +55,10 @@ def convert_sklearn_kernel_pca(operator, device, extra_config):
         kernel = operator.raw_operator.kernel
         degree = operator.raw_operator.degree
         sv = operator.raw_operator.X_fit_
-        non_zeros = np.flatnonzero(operator.raw_operator.lambdas_)
+        non_zeros = np.flatnonzero(operator.raw_operator.eigenvalues_)
         scaled_alphas = np.zeros_like(operator.raw_operator.alphas_)
         scaled_alphas[:, non_zeros] = operator.raw_operator.alphas_[:, non_zeros] / np.sqrt(
-            operator.raw_operator.lambdas_[non_zeros]
+            operator.raw_operator.eigenvalues_[non_zeros]
         )
         return KernelPCA(
             operator,

--- a/hummingbird/ml/operator_converters/sklearn/decomposition.py
+++ b/hummingbird/ml/operator_converters/sklearn/decomposition.py
@@ -56,8 +56,8 @@ def convert_sklearn_kernel_pca(operator, device, extra_config):
         degree = operator.raw_operator.degree
         sv = operator.raw_operator.X_fit_
         non_zeros = np.flatnonzero(operator.raw_operator.eigenvalues_)
-        scaled_alphas = np.zeros_like(operator.raw_operator.alphas_)
-        scaled_alphas[:, non_zeros] = operator.raw_operator.alphas_[:, non_zeros] / np.sqrt(
+        scaled_alphas = np.zeros_like(operator.raw_operator.eigenvectors_)
+        scaled_alphas[:, non_zeros] = operator.raw_operator.eigenvectors_[:, non_zeros] / np.sqrt(
             operator.raw_operator.eigenvalues_[non_zeros]
         )
         return KernelPCA(

--- a/hummingbird/ml/operator_converters/sklearn/gbdt.py
+++ b/hummingbird/ml/operator_converters/sklearn/gbdt.py
@@ -17,11 +17,7 @@ from .._tree_commons import get_parameters_for_sklearn_common, get_parameters_fo
 
 
 def _get_n_features(model):
-    try:
-        return model.n_features_in_
-    except AttributeError:
-        # HistGradientBoosting
-        return model._n_features
+    return model.n_features_in_
 
 
 def _get_parameters_hist_gbdt(trees, extra_config):

--- a/hummingbird/ml/operator_converters/sklearn/linear.py
+++ b/hummingbird/ml/operator_converters/sklearn/linear.py
@@ -30,7 +30,7 @@ def convert_sklearn_linear_model(operator, device, extra_config):
     """
     assert operator is not None, "Cannot convert None operator"
 
-    supported_loss = {"log", "modified_huber", "squared_hinge"}
+    supported_loss = {"log_loss", "modified_huber", "squared_hinge"}
     classes = [0] if not hasattr(operator.raw_operator, "classes_") else operator.raw_operator.classes_
 
     if not all(["int" in str(type(x)) for x in classes]):

--- a/hummingbird/ml/operator_converters/sklearn/nb.py
+++ b/hummingbird/ml/operator_converters/sklearn/nb.py
@@ -89,10 +89,10 @@ def convert_sklearn_gaussian_naive_bayes(operator, device, extra_config):
     if not all([type(x) in [int, np.int32, np.int64] for x in classes]):
         raise RuntimeError("Hummingbird supports only integer labels for class labels.")
 
-    jll_calc_bias = np.log(model.class_prior_.reshape(-1, 1)) - 0.5 * np.sum(np.log(2.0 * np.pi * model.sigma_), 1).reshape(
+    jll_calc_bias = np.log(model.class_prior_.reshape(-1, 1)) - 0.5 * np.sum(np.log(2.0 * np.pi * model.var_), 1).reshape(
         -1, 1
     )
-    return GaussianNBModel(operator, classes, jll_calc_bias, model.theta_, model.sigma_, device)
+    return GaussianNBModel(operator, classes, jll_calc_bias, model.theta_, model.var_, device)
 
 
 register_converter("SklearnBernoulliNB", convert_sklearn_bernouli_naive_bayes)

--- a/hummingbird/ml/supported.py
+++ b/hummingbird/ml/supported.py
@@ -120,9 +120,6 @@ def _build_sklearn_operator_list():
     Put all suported Sklearn operators on a list.
     """
     if sklearn_installed():
-        # Enable experimental to import HistGradientBoosting*
-        from sklearn.experimental import enable_hist_gradient_boosting
-
         # Tree-based models
         from sklearn.ensemble import (
             ExtraTreesClassifier,

--- a/tests/test_sklearn_clustering.py
+++ b/tests/test_sklearn_clustering.py
@@ -20,7 +20,7 @@ except Exception:
 
 class TestSklearnClustering(unittest.TestCase):
     # KMeans test function to be parameterized
-    def _test_kmeans(self, n_clusters, algorithm="full", backend="torch", extra_config={}):
+    def _test_kmeans(self, n_clusters, algorithm="lloyd", backend="torch", extra_config={}):
         model = KMeans(n_clusters=n_clusters, algorithm=algorithm, random_state=0)
         np.random.seed(0)
         X = np.random.rand(100, 200)
@@ -41,11 +41,11 @@ class TestSklearnClustering(unittest.TestCase):
 
     # KMeans 2 auto
     def test_kmeans_2_auto(self):
-        self._test_kmeans(2, "auto")
+        self._test_kmeans(2, "lloyd")
 
     # KMeans 5 full
     def test_kmeans_5_auto(self):
-        self._test_kmeans(5, "auto")
+        self._test_kmeans(5, "lloyd")
 
     # KMeans 2 elkan
     def test_kmeans_2_elkan(self):

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -179,7 +179,7 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
     # SGDClassifier test function to be parameterized
     def _test_sgd_classifier(self, num_classes):
 
-        model = SGDClassifier(loss="log")
+        model = SGDClassifier(loss="log_loss")
 
         np.random.seed(0)
         X = np.random.rand(100, 200)
@@ -266,7 +266,7 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
 
     def test_float64_sgd_classifier(self):
 
-        model = SGDClassifier(loss="log")
+        model = SGDClassifier(loss="log_loss")
 
         np.random.seed(0)
         num_classes = 3
@@ -332,7 +332,7 @@ class TestSklearnLinearClassifiers(unittest.TestCase):
     @unittest.skipIf(not (tvm_installed()), reason="TVM tests require TVM")
     def test_sgd_classifier_tvm(self):
 
-        model = SGDClassifier(loss="log")
+        model = SGDClassifier(loss="log_loss")
 
         np.random.seed(0)
         num_classes = 3


### PR DESCRIPTION
Fix #606 and more

- Since version 1.0,  it is not needed to import enable_hist_gradient_boosting anymore
  - [sklearn.experimental.enable_hist_gradient_boosting — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.experimental.enable_hist_gradient_boosting.html)
- `sigma_` is deprecated in 1.0 and will be removed in 1.2. Use `var_` instead.
  - [sklearn.naive_bayes.GaussianNB — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.naive_bayes.GaussianNB.html)
- FutureWarning: algorithm='auto' is deprecated, it will be removed in 1.3. Using 'lloyd' instead.
  - [sklearn.cluster.k_means — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.k_means.html)
- FutureWarning: algorithm='full' is deprecated, it will be removed in 1.3. Using 'lloyd' instead.
  - [sklearn.cluster.k_means — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.cluster.k_means.html)
- DeprecationWarning: Please use `csr_matrix` from the `scipy.sparse` namespace, the `scipy.sparse.csr` namespace is deprecated.
  - [scipy.sparse.csr_matrix — SciPy v1.9.0 Manual](https://docs.scipy.org/doc/scipy/reference/generated/scipy.sparse.csr_matrix.html)
- FutureWarning: The loss 'log' was deprecated in v1.1 and will be removed in version 1.3. Use `loss='log_loss'` which is equivalent.
  - [sklearn.linear_model.SGDClassifier — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.linear_model.SGDClassifier.html)
- FutureWarning: Attribute `lambdas_` was deprecated in version 1.0 and will be removed in 1.2. Use `eigenvalues_` instead.
  - [sklearn.decomposition.KernelPCA — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html)
- FutureWarning: Attribute `alphas_` was deprecated in version 1.0 and will be removed in 1.2. Use `eigenvectors_` instead.
  - [sklearn.decomposition.KernelPCA — scikit-learn 1.1.2 documentation](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.KernelPCA.html)
