### PR TITLE
update codecov/codecov-action to v3

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -134,7 +134,7 @@ jobs:
         coverage xml
     - name: Upload coverage to Codecov
       if: ${{ matrix.python-version == '3.8' && startsWith(matrix.os, 'ubuntu') }}
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml
         flags: unittests


### PR DESCRIPTION
Because v1 was deprecated.
[codecov/codecov-action: GitHub Action that uploads coverage to Codecov](https://github.com/codecov/codecov-action#%EF%B8%8F--deprecation-of-v1)