### PR TITLE
chore: update deprecated calls

### DIFF
--- a/benchmarks/datasets.py
+++ b/benchmarks/datasets.py
@@ -23,7 +23,6 @@
 # Copyright (c) 2018, NVIDIA CORPORATION. All rights reserved.
 
 import os
-import sys
 from enum import Enum
 import pandas as pd
 import pickle
@@ -32,10 +31,7 @@ import numpy as np
 from sklearn.model_selection import train_test_split
 from sklearn.datasets import load_svmlight_file
 
-if sys.version_info[0] >= 3:
-    from urllib.request import urlretrieve
-else:
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 
 
 class LearningTask(Enum):

--- a/benchmarks/pipelines/openml_pipelines.py
+++ b/benchmarks/pipelines/openml_pipelines.py
@@ -4,7 +4,7 @@
 # license information.
 # --------------------------------------------------------------------------
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import openml
 import sklearn
 import operator
@@ -240,8 +240,8 @@ if __name__ == "__main__":
             if openml.tasks.get_task(task_id).get_dataset().features[i].data_type == "nominal" and i < X.shape[1]
         ]
 
-        vers = LooseVersion(openml.__version__)
-        renamed_version = LooseVersion("0.11")
+        vers = parse(openml.__version__)
+        renamed_version = Version("0.11")
         if vers < renamed_version:
             runs_df = openml.evaluations.list_evaluations(
                 function="predictive_accuracy", task=[task_id], output_format="dataframe"

--- a/hummingbird/ml/_topology.py
+++ b/hummingbird/ml/_topology.py
@@ -9,7 +9,7 @@ Converters for topology IR are stored in this file.
 """
 import numpy as np
 import os
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import torch
 from uuid import uuid4
 
@@ -212,7 +212,7 @@ def convert(topology, backend, test_input, device, extra_config={}):
 
         if backend == onnx.__name__:
             # Pytorch <= 1.4.0 has a bug with exporting GEMM into ONNX.
-            if LooseVersion(torch.__version__) <= LooseVersion("1.4"):
+            if parse(torch.__version__) <= Version("1.4"):
                 # Raise en error and warn user that the torch version is not supported with onnx backend
                 raise Exception(
                     f"The current torch version {torch.__version__} is not supported with {backend} backend. "

--- a/hummingbird/ml/_utils.py
+++ b/hummingbird/ml/_utils.py
@@ -8,7 +8,7 @@
 Collection of utility functions used throughout Hummingbird.
 """
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 from types import ModuleType
 import numpy as np
 import torch
@@ -26,7 +26,7 @@ def torch_installed():
     try:
         import torch
         assert (
-            LooseVersion(torch.__version__) > LooseVersion("1.7.0")
+            parse(torch.__version__) > Version("1.7.0")
         ), "Please install torch >1.7.0"
 
         return True
@@ -141,8 +141,8 @@ def xgboost_installed():
         return False
     from xgboost import __version__
 
-    vers = LooseVersion(__version__)
-    allowed_min = LooseVersion("0.90")
+    vers = parse(__version__)
+    allowed_min = Version("0.90")
     if vers < allowed_min:
         warnings.warn("The converter works for xgboost >= 0.9. Different versions might not.")
     return True
@@ -306,7 +306,7 @@ def check_dumped_versions(configurations, *args):
         assert isinstance(current_version, ModuleType)
         if current_version.__name__ in versions:
             loaded_version = versions[current_version.__name__]
-            if LooseVersion(loaded_version) != LooseVersion(current_version.__version__):
+            if parse(loaded_version) != parse(current_version.__version__):
                 warnings.warn(
                     "Version of {} used to save the model ({}) is different than the current version ({}).".format(
                         current_version.__name__, loaded_version, current_version.__version__

--- a/hummingbird/ml/operator_converters/sklearn/bagging.py
+++ b/hummingbird/ml/operator_converters/sklearn/bagging.py
@@ -8,7 +8,7 @@
 Converter for Bagging operators.
 """
 
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import numpy as np
 from onnxconverter_common.registration import register_converter
 import torch

--- a/hummingbird/ml/operator_converters/sklearn/poly_features.py
+++ b/hummingbird/ml/operator_converters/sklearn/poly_features.py
@@ -78,7 +78,7 @@ def convert_sklearn_poly_features(operator, device, extra_config):
         raise NotImplementedError("Hummingbird currently only supports degree 2 for PolynomialFeatures")
     return PolynomialFeatures(
         operator,
-        operator.raw_operator.n_input_features_,
+        operator.raw_operator.n_features_in_,
         operator.raw_operator.degree,
         operator.raw_operator.interaction_only,
         operator.raw_operator.include_bias,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line-length = 127
 include = '\.pyi?$'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
-from distutils.core import setup
-from setuptools import find_packages
+from setuptools import find_packages, setup
 import os
-import sys
 
 this = os.path.dirname(__file__)
 

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -7,7 +7,7 @@ import os
 import sys
 import numpy as np
 from typing import Iterator
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import shutil
 
 from sklearn.ensemble import GradientBoostingClassifier
@@ -756,7 +756,7 @@ class TestBackends(unittest.TestCase):
 
     # Test Spark UDF
     @unittest.skipIf(
-        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or parse(pyspark.__version__) < Version("3"),
         reason="UDF Test requires spark >= 3",
     )
     @unittest.skipIf(
@@ -798,7 +798,7 @@ class TestBackends(unittest.TestCase):
         sql_context.sql("SELECT SUM(prediction) FROM (SELECT PREDICT(*) as prediction FROM IRIS)").show()
 
     @unittest.skipIf(
-        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or parse(pyspark.__version__) < Version("3"),
         reason="UDF Test requires spark >= 3",
     )
     def test_udf_torch_jit_broadcast(self):
@@ -823,7 +823,7 @@ class TestBackends(unittest.TestCase):
         self.assertRaises(pickle.PickleError, spark.sparkContext.broadcast, hb_model)
 
     @unittest.skipIf(
-        os.name == "nt" or not sparkml_installed() or LooseVersion(pyspark.__version__) < LooseVersion("3"),
+        os.name == "nt" or not sparkml_installed() or parse(pyspark.__version__) < Version("3"),
         reason="UDF Test requires spark >= 3",
     )
     @unittest.skipIf(

--- a/tests/test_extra_conf.py
+++ b/tests/test_extra_conf.py
@@ -1,7 +1,7 @@
 """
 Tests extra configurations.
 """
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import unittest
 import warnings
 import sys
@@ -39,7 +39,7 @@ if onnx_ml_tools_installed():
 class TestExtraConf(unittest.TestCase):
     # Test default number of threads. It will only work on mac after 1.6 https://github.com/pytorch/pytorch/issues/43036
     @unittest.skipIf(
-        sys.platform == "darwin" and LooseVersion(torch.__version__) <= LooseVersion("1.6.0"),
+        sys.platform == "darwin" and parse(torch.__version__) <= Version("1.6.0"),
         reason="PyTorch has a bug on mac related to multi-threading",
     )
     def test_torch_deafault_n_threads(self):
@@ -62,7 +62,7 @@ class TestExtraConf(unittest.TestCase):
 
     # Test one thread in pytorch.
     @unittest.skipIf(
-        sys.platform == "darwin" and LooseVersion(torch.__version__) > LooseVersion("1.6.0"),
+        sys.platform == "darwin" and parse(torch.__version__) > Version("1.6.0"),
         reason="Setting threading multi times will break on mac",
     )
     def test_torch_one_thread(self):

--- a/tests/test_onnxml_label_encoder_converter.py
+++ b/tests/test_onnxml_label_encoder_converter.py
@@ -1,7 +1,7 @@
 """
 Tests onnxml LabelEncoder converter
 """
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import unittest
 import warnings
 
@@ -57,7 +57,7 @@ class TestONNXLabelEncoder(unittest.TestCase):
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test requires ONNX, ORT and ONNXMLTOOLS"
     )
     @unittest.skipIf(
-        LooseVersion(torch.__version__) < LooseVersion("1.8.0"),
+        parse(torch.__version__) < Version("1.8.0"),
         reason="PyTorch exporter don't support nonzero until version 1.8.0",
     )
     def test_model_label_encoder_str_onnxml(self):
@@ -91,7 +91,7 @@ class TestONNXLabelEncoder(unittest.TestCase):
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test requires ONNX, ORT and ONNXMLTOOLS"
     )
     @unittest.skipIf(
-        LooseVersion(torch.__version__) >= LooseVersion("1.8.0"),
+        parse(torch.__version__) >= Version("1.8.0"),
         reason="PyTorch exporter supports nonzero only from version 1.8.0 and should fail on older versions",
     )
     def test_le_string_raises_rt_onnx(self):

--- a/tests/test_onnxml_one_hot_encoder_converter.py
+++ b/tests/test_onnxml_one_hot_encoder_converter.py
@@ -1,7 +1,7 @@
 """
 Tests onnxml OneHotEncoderconverter
 """
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 import unittest
 import warnings
 
@@ -111,7 +111,7 @@ class TestONNXOneHotEncoder(unittest.TestCase):
         not (onnx_ml_tools_installed() and onnx_runtime_installed()), reason="ONNXML test requires ONNX, ORT and ONNXMLTOOLS"
     )
     @unittest.skipIf(
-        LooseVersion(torch.__version__) < LooseVersion("1.8.0"),
+        parse(torch.__version__) < Version("1.8.0"),
         reason="PyTorch exporter returns an error until version 1.8.0",
     )
     def test_model_one_hot_encoder_string(self):

--- a/tests/test_prophet.py
+++ b/tests/test_prophet.py
@@ -1,7 +1,6 @@
 import unittest
 import numpy as np
 import os
-import sys
 import torch
 from packaging.version import Version, parse
 
@@ -17,10 +16,7 @@ if prophet_installed():
 if onnx_runtime_installed():
     import onnxruntime
 
-if sys.version_info[0] >= 3:
-    from urllib.request import urlretrieve
-else:
-    from urllib import urlretrieve
+from urllib.request import urlretrieve
 
 
 class TestProphet(unittest.TestCase):

--- a/tests/test_prophet.py
+++ b/tests/test_prophet.py
@@ -3,7 +3,7 @@ import numpy as np
 import os
 import sys
 import torch
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 import hummingbird
 from hummingbird.ml._utils import pandas_installed, prophet_installed, onnx_runtime_installed
@@ -55,7 +55,7 @@ class TestProphet(unittest.TestCase):
         not (pandas_installed() and prophet_installed()), reason="Test requires Prophet, Pandas and ONNX runtime.",
     )
     @unittest.skipIf(
-        not onnx_runtime_installed() or LooseVersion(onnxruntime.__version__) < LooseVersion("1.7.0"),
+        not onnx_runtime_installed() or parse(onnxruntime.__version__) < Version("1.7.0"),
         reason="Prophet test requires onnxruntime => 1.7.0",
     )
     def test_prophet_trend_onnx(self):

--- a/tests/test_sklearn_decomposition.py
+++ b/tests/test_sklearn_decomposition.py
@@ -48,7 +48,7 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
         reason="With Sklearn version < 0.23.2 returns ValueError: math domain error (https://github.com/scikit-learn/scikit-learn/issues/4441)",
     )
     def test_pca_converter_mle_whiten(self):
-        self._fit_model_pca(PCA(n_components="mle", whiten=True))
+        self._fit_model_pca(PCA(n_components="mle", whiten="arbitrary-variance"))
 
     # PCA n_componenets mle and solver full
     @unittest.skipIf(
@@ -113,7 +113,7 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
 
     # FastICA converter with n_components 3 whiten
     def test_fast_ica_converter_3_whiten(self):
-        self._fit_model_pca(FastICA(n_components=3, whiten=True))
+        self._fit_model_pca(FastICA(n_components=3, whiten="arbitrary-variance"))
 
     # FastICA converter with n_components 3 deflation algorithm
     def test_fast_ica_converter_3_deflation(self):

--- a/tests/test_sklearn_decomposition.py
+++ b/tests/test_sklearn_decomposition.py
@@ -4,7 +4,7 @@ Tests sklearn matrix decomposition converters
 import unittest
 import warnings
 import sys
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 import numpy as np
 import torch
@@ -44,7 +44,7 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
 
     # PCA n_componenets mle and whiten true
     @unittest.skipIf(
-        LooseVersion(sklearn.__version__) < LooseVersion("0.23.2"),
+        parse(sklearn.__version__) < Version("0.23.2"),
         reason="With Sklearn version < 0.23.2 returns ValueError: math domain error (https://github.com/scikit-learn/scikit-learn/issues/4441)",
     )
     def test_pca_converter_mle_whiten(self):
@@ -52,7 +52,7 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
 
     # PCA n_componenets mle and solver full
     @unittest.skipIf(
-        LooseVersion(sklearn.__version__) < LooseVersion("0.23.2"),
+        parse(sklearn.__version__) < Version("0.23.2"),
         reason="With Sklearn version < 0.23.2 returns ValueError: math domain error (https://github.com/scikit-learn/scikit-learn/issues/4441)",
     )
     def test_pca_converter_mle_full(self):

--- a/tests/test_sklearn_feature_union.py
+++ b/tests/test_sklearn_feature_union.py
@@ -5,7 +5,6 @@
 # --------------------------------------------------------------------------
 
 import unittest
-from distutils.version import StrictVersion
 
 import numpy as np
 from sklearn.datasets import load_digits, load_iris

--- a/tests/test_sklearn_kneighbors.py
+++ b/tests/test_sklearn_kneighbors.py
@@ -2,7 +2,7 @@
 Tests sklearn KNeighbor model (KNeighborsClassifier, KNeighborsRegressor) converters.
 """
 import unittest
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 import numpy as np
 import sklearn
@@ -89,7 +89,7 @@ class TestSklearnKNeighbors(unittest.TestCase):
 
     # KNeighborsClassifier wminkowski metric type
     @unittest.skipIf(
-        LooseVersion(sklearn.__version__) > LooseVersion("1.0"),
+        parse(sklearn.__version__) > Version("1.0"),
         reason="wminkowski metric is not supported anymore for sklearn > 1.0",
     )
     def test_kneighbors_classifer_wminkowski(self):
@@ -183,7 +183,7 @@ class TestSklearnKNeighbors(unittest.TestCase):
 
     # KNeighborsRegressor wminkowski metric type
     @unittest.skipIf(
-        LooseVersion(sklearn.__version__) > LooseVersion("1.0"),
+        parse(sklearn.__version__) > Version("1.0"),
         reason="wminkowski metric is not supported anymore for sklearn > 1.0",
     )
     def test_kneighbors_regressor_wminkowski(self):

--- a/tests/test_sklearn_linear_converter.py
+++ b/tests/test_sklearn_linear_converter.py
@@ -3,7 +3,7 @@ Tests sklearn linear classifiers (LinearRegression, LogisticRegression, SGDClass
 """
 import unittest
 import warnings
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 import numpy as np
 import torch

--- a/tests/test_sparkml_linear_converter.py
+++ b/tests/test_sparkml_linear_converter.py
@@ -9,7 +9,7 @@ import torch
 
 from hummingbird.ml._utils import sparkml_installed, pandas_installed
 from hummingbird.ml import convert
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 if sparkml_installed():
     from pyspark.sql import SparkSession, SQLContext

--- a/tests/test_sparkml_vector_assembler.py
+++ b/tests/test_sparkml_vector_assembler.py
@@ -7,7 +7,7 @@ import warnings
 import numpy as np
 import torch
 from sklearn.datasets import load_iris
-from distutils.version import LooseVersion
+from packaging.version import Version, parse
 
 from hummingbird.ml._utils import sparkml_installed, pandas_installed
 from hummingbird.ml import convert

--- a/website/sphinx/conf.py
+++ b/website/sphinx/conf.py
@@ -39,9 +39,9 @@ extensions = [
 
 # pngmath / imgmath compatibility layer for different sphinx versions
 import sphinx  # noqa: E402
-from distutils.version import LooseVersion  # noqa: E402
+from packaging.version import Version, parse  # noqa: E402
 
-if LooseVersion(sphinx.__version__) < LooseVersion("1.4"):
+if parse(sphinx.__version__) < Version("1.4"):
     extensions.append("sphinx.ext.pngmath")
 else:
     extensions.append("sphinx.ext.imgmath")


### PR DESCRIPTION
Addresses a few deprecation warnings which I saw:

- Deprecated SKLearn API calls
- Replaces `distutils.version` with `packaging.version` calls. Calls `parse` if the version string is package provided, calls `Version` if the version string is hard coded.
- Drops the deprecated`distutils` entirely to use `setuptools` for everything.
- Drops unnecessary Python 2 backports.

I have signed the Microsoft CLA.  