### PR TITLE
allow for identity POST_TRANSFORM

### DIFF
--- a/hummingbird/ml/operator_converters/_gbdt_commons.py
+++ b/hummingbird/ml/operator_converters/_gbdt_commons.py
@@ -13,6 +13,7 @@ import numpy as np
 from . import constants
 from ._tree_commons import get_tree_params_and_type, get_parameters_for_tree_trav_common, get_parameters_for_gemm_common
 from ._tree_commons import (
+    PostTransform,
     ApplySigmoidPostTransform,
     ApplySoftmaxPostTransform,
     ApplyTweediePostTransform,
@@ -160,6 +161,8 @@ def convert_gbdt_common(
                 extra_config[constants.POST_TRANSFORM] = ApplyTweedieBasePredictionPostTransform(base_prediction)
             else:
                 extra_config[constants.POST_TRANSFORM] = ApplyTweediePostTransform()
+        elif extra_config[constants.POST_TRANSFORM] is None:
+            extra_config[constants.POST_TRANSFORM] = PostTransform()
         else:
             raise NotImplementedError("Post transform {} not implemeneted yet".format(extra_config[constants.POST_TRANSFORM]))
     elif constants.BASE_PREDICTION in extra_config:


### PR DESCRIPTION
In https://github.com/ludwig-ai/ludwig, we require access to the raw logits since we already have our own "post-transform" logic. With this PR, a user can predict raw logits by using the following `extra_config`:

```python
from hummingbird.ml import convert
from hummingbird.ml.operator_converters import constants

lgbm_model = ...
convert(lgbm_model, "torch", extra_config={constants.POST_TRANSFORM: None})
```