### PR TITLE
Fix SGDClassifier predict result bug

### DIFF
--- a/hummingbird/ml/operator_converters/_linear_implementations.py
+++ b/hummingbird/ml/operator_converters/_linear_implementations.py
@@ -36,10 +36,6 @@ class LinearModel(PhysicalOperator, torch.nn.Module):
         if self.loss is None and self.classification:
             self.loss = "log"
 
-        self.perform_class_select = False
-        if min(classes) != 0 or max(classes) != len(classes) - 1:
-            self.perform_class_select = True
-
         self.binary_classification = False
         if len(classes) == 2:
             self.binary_classification = True


### PR DESCRIPTION
The bug is described in #702.

Here is one possible solution. I made changes to the code logic, so that the original prediction result should be computed in advance instead of being calculated at the end using the `output` (which is actually the result of `predict_prob`)