### PR TITLE
Pin cython version to avoid TVM build error on macOS

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -128,6 +128,7 @@ jobs:
       working-directory: ../tvm/python
       run: |
         python -m pip install -U wheel packaging
+        python -m pip install cython==0.29.34
         python setup.py bdist_wheel
         python -m pip install dist/tvm-*.whl
 


### PR DESCRIPTION
Fix #727 