### PR TITLE
Move coverage to mac from Ubuntu

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -135,18 +135,18 @@ jobs:
         cd ~/work/hummingbird/tvm/python
         python3 -m pip install -e .
 
-    # We don't run pytest for Linux py3.9 since we do coverage for that case.
+    # We don't run pytest for macos py3.9 since we do coverage for that case.
     - name: Test with pytest
-      if: ${{ matrix.python-version != '3.9' || startsWith(matrix.os, 'ubuntu') != true }}
+      if: ${{ matrix.python-version != '3.9' || startsWith(matrix.os, 'macos') != true }}
       run: pytest
-    # Run and push coverage only for Linux py3.9
-    - name: Coverage 3.9 Linux
-      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}
+    # Run and push coverage only for macos py3.9
+    - name: Coverage 3.9 macos
+      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'macos') }}
       run: |
         coverage run -a -m pytest tests
         coverage xml
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'macos') }}
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml


### PR DESCRIPTION
Since we don't run TVM tests on ubuntu now, switch coverage run to macos runner.

This should bump coverage back up to 90% from 88% due to not sending Coverage the TVM runs