### PR TITLE
Forcing users to set override flag to unzip without hash integrity check

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -135,18 +135,18 @@ jobs:
         cd ~/work/hummingbird/tvm/python
         python3 -m pip install -e .
 
-    # We don't run pytest for Linux py3.9 since we do coverage for that case.
+    # We don't run pytest for macos py3.9 since we do coverage for that case.
     - name: Test with pytest
-      if: ${{ matrix.python-version != '3.9' || startsWith(matrix.os, 'ubuntu') != true }}
+      if: ${{ matrix.python-version != '3.9' || startsWith(matrix.os, 'macos') != true }}
       run: pytest
-    # Run and push coverage only for Linux py3.9
-    - name: Coverage 3.9 Linux
-      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}
+    # Run and push coverage only for macos py3.9
+    - name: Coverage 3.9 macos
+      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'macos') }}
       run: |
         coverage run -a -m pytest tests
         coverage xml
     - name: Upload coverage to Codecov
-      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'ubuntu') }}
+      if: ${{ matrix.python-version == '3.9' && startsWith(matrix.os, 'macos') }}
       uses: codecov/codecov-action@v3
       with:
         file: ./coverage.xml

--- a/hummingbird/ml/_utils.py
+++ b/hummingbird/ml/_utils.py
@@ -241,13 +241,14 @@ def from_strings_to_ints(input, max_string_length):
     return np.array(input, dtype="|S" + str(max_string_length)).view(np.int32).reshape(shape)
 
 
-def load(location, digest=None):
+def load(location, digest=None, override_flag=False):
     """
     Utility function used to load arbitrary Hummingbird models.
 
     Args:
         location: The location of the model.
         digest (optional): A digest string to verify the model integrity (created during save).
+        override_flag (optional): A flag to override the integrity check. Set to True to bypass if trusted source.
     """
     # Add load capabilities.
     from hummingbird.ml.containers import PyTorchSklearnContainer
@@ -270,7 +271,11 @@ def load(location, digest=None):
 
     # Verify the digest if provided.
     if digest is None:
-        print("Warning: No digest provided. Model integrity not verified.")
+        if override_flag is False:
+            raise RuntimeError("No digest provided. If you trust the source of this model, "
+                  "set override_flag to True. Ex: .load(location, override_flag=True)")
+        else:
+            print("Skipping integrity check. Override flag set to True.")
     else:
         with open(zip_location, 'rb') as file:
             new_digest = hmac.new(b'shared-key', file.read(), hashlib.sha1).hexdigest()

--- a/hummingbird/ml/containers/sklearn/onnx_containers.py
+++ b/hummingbird/ml/containers/sklearn/onnx_containers.py
@@ -107,13 +107,15 @@ class ONNXSklearnContainer(SklearnContainer):
         return digest
 
     @staticmethod
-    def load(location, do_unzip_and_model_type_check=True, digest=None):
+    def load(location, do_unzip_and_model_type_check=True, digest=None, override_flag=False):
         """
         Method used to load a container from the file system.
 
         Args:
             location: The location on the file system where to load the model.
             do_unzip_and_model_type_check: Whether to unzip the model and check the type.
+            digest (optional): The digest to verify the integrity of the model.
+            override_flag (optional): A flag to override the integrity check. Set to True to bypass if trusted source.
 
         Returns:
             The loaded model.
@@ -138,7 +140,11 @@ class ONNXSklearnContainer(SklearnContainer):
 
             # Verify the digest if provided.
             if digest is None:
-                print("Warning: No digest provided. Model integrity not verified.")
+                if override_flag is False:
+                    raise RuntimeError("No digest provided. If you trust the source of this model, "
+                                       "set override_flag to True. Ex: .load(location, override_flag=True)")
+                else:
+                    print("Skipping integrity check. Override flag set to True.")
             else:
                 with open(zip_location, 'rb') as file:
                     new_digest = hmac.new(b'shared-key', file.read(), hashlib.sha1).hexdigest()

--- a/hummingbird/ml/containers/sklearn/pytorch_containers.py
+++ b/hummingbird/ml/containers/sklearn/pytorch_containers.py
@@ -105,7 +105,8 @@ class PyTorchSklearnContainer(SklearnContainer):
         return digest
 
     @staticmethod
-    def load(location, do_unzip_and_model_type_check=True, delete_unzip_location_folder: bool = True, digest=None):
+    def load(location, do_unzip_and_model_type_check=True, delete_unzip_location_folder: bool = True,
+             digest=None, override_flag=False):
         """
         Method used to load a container from the file system.
 
@@ -114,6 +115,8 @@ class PyTorchSklearnContainer(SklearnContainer):
             do_unzip_and_model_type_check: Whether to unzip the model and check the type.
             delete_unzip_location_folder: Whether to delete the folder provided by caller or created by this method
                                             where the model is unzipped
+            digest (optional): The digest to verify the integrity of the model.
+            override_flag (optional): A flag to override the integrity check. Set to True to bypass if trusted source.
 
         Returns:
             The loaded model.
@@ -133,7 +136,11 @@ class PyTorchSklearnContainer(SklearnContainer):
 
             # Verify the digest if provided.
             if digest is None:
-                print("Warning: No digest provided. Model integrity not verified.")
+                if override_flag is False:
+                    raise RuntimeError("No digest provided. If you trust the source of this model, "
+                                       "set override_flag to True. Ex: .load(location, override_flag=True)")
+                else:
+                    print("Skipping integrity check. Override flag set to True.")
             else:
                 with open(zip_location, 'rb') as file:
                     new_digest = hmac.new(b'shared-key', file.read(), hashlib.sha1).hexdigest()

--- a/hummingbird/ml/containers/sklearn/tvm_containers.py
+++ b/hummingbird/ml/containers/sklearn/tvm_containers.py
@@ -129,13 +129,15 @@ class TVMSklearnContainer(SklearnContainer):
         return digest
 
     @staticmethod
-    def load(location, do_unzip_and_model_type_check=True, digest=None):
+    def load(location, do_unzip_and_model_type_check=True, digest=None, override_flag=False):
         """
         Method used to load a container from the file system.
 
         Args:
             location: The location on the file system where to load the model.
             do_unzip_and_model_type_check: Whether to unzip the model and check the type.
+            digest (optional): The digest to verify the integrity of the model.
+            override_flag (optional): A flag to override the integrity check. Set to True to bypass if trusted source.
 
         Returns:
             The loaded model.
@@ -159,7 +161,11 @@ class TVMSklearnContainer(SklearnContainer):
 
             # Verify the digest if provided.
             if digest is None:
-                print("Warning: No digest provided. Model integrity not verified.")
+                if override_flag is False:
+                    raise RuntimeError("No digest provided. If you trust the source of this model, "
+                                       "set override_flag to True. Ex: .load(location, override_flag=True)")
+                else:
+                    print("Skipping integrity check. Override flag set to True.")
             else:
                 with open(zip_location, 'rb') as file:
                     new_digest = hmac.new(b'shared-key', file.read(), hashlib.sha1).hexdigest()

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -114,7 +114,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("pt-tmp")
 
-        hb_model_loaded = hummingbird.ml.TorchContainer.load("pt-tmp")
+        hb_model_loaded = hummingbird.ml.TorchContainer.load("pt-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("pt-tmp.zip")
@@ -163,10 +163,10 @@ class TestBackends(unittest.TestCase):
         hb_model.save(model_location_name)
 
         # Default behavior
-        hummingbird.ml.TorchContainer.load(model_location_name, delete_unzip_location_folder=True)
+        hummingbird.ml.TorchContainer.load(model_location_name, delete_unzip_location_folder=True, override_flag=True)
         assert not os.path.exists(model_location_name)
 
-        hummingbird.ml.TorchContainer.load(model_location_name, delete_unzip_location_folder=False)
+        hummingbird.ml.TorchContainer.load(model_location_name, delete_unzip_location_folder=False, override_flag=True)
         assert os.path.exists(model_location_name)
 
         os.remove(f"{model_location_name}.zip")
@@ -189,7 +189,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("pt-tmp")
 
-        hb_model_loaded = hummingbird.ml.load("pt-tmp")
+        hb_model_loaded = hummingbird.ml.load("pt-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("pt-tmp.zip")
@@ -210,8 +210,8 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("pt-tmp")
 
-        hummingbird.ml.load("pt-tmp")
-        hummingbird.ml.load("pt-tmp")
+        hummingbird.ml.load("pt-tmp", override_flag=True)
+        hummingbird.ml.load("pt-tmp", override_flag=True)
 
         os.remove("pt-tmp.zip")
 
@@ -244,7 +244,7 @@ class TestBackends(unittest.TestCase):
             file.writelines(configuration)
         shutil.make_archive("pt-tmp", "zip", "pt-tmp")
 
-        hummingbird.ml.load("pt-tmp")
+        hummingbird.ml.load("pt-tmp", override_flag=True)
         os.remove("pt-tmp.zip")
 
     def test_pytorch_save_load_less_versions(self):
@@ -276,7 +276,7 @@ class TestBackends(unittest.TestCase):
             file.writelines(configuration)
         shutil.make_archive("pt-tmp", "zip", "pt-tmp")
 
-        hummingbird.ml.load("pt-tmp")
+        hummingbird.ml.load("pt-tmp", override_flag=True)
         os.remove("pt-tmp.zip")
 
     def test_pytorch_save_load_different_versions(self):
@@ -308,7 +308,7 @@ class TestBackends(unittest.TestCase):
             file.writelines(configuration)
         shutil.make_archive("pt-tmp", "zip", "pt-tmp")
 
-        hummingbird.ml.load("pt-tmp")
+        hummingbird.ml.load("pt-tmp", override_flag=True)
         os.remove("pt-tmp.zip")
 
     # Test torchscript save and load
@@ -328,7 +328,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("ts-tmp")
 
-        hb_model_loaded = hummingbird.ml.TorchContainer.load("ts-tmp")
+        hb_model_loaded = hummingbird.ml.TorchContainer.load("ts-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("ts-tmp.zip")
@@ -375,7 +375,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("ts-tmp")
 
-        hb_model_loaded = hummingbird.ml.load("ts-tmp")
+        hb_model_loaded = hummingbird.ml.load("ts-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("ts-tmp.zip")
@@ -480,7 +480,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("tvm-tmp")
 
-        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp")
+        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("tvm-tmp.zip")
@@ -507,7 +507,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         my_digest = hb_model.save("tvm-tmp")
 
-        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp", digest=my_digest)
+        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp", digest=my_digest, override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         # Now try to load with a different digest
@@ -537,7 +537,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("tvm-tmp")
 
-        hb_model_loaded = hummingbird.ml.load("tvm-tmp")
+        hb_model_loaded = hummingbird.ml.load("tvm-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("tvm-tmp.zip")
@@ -564,7 +564,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("tvm-tmp.zip")
 
-        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp.zip")
+        hb_model_loaded = hummingbird.ml.TVMContainer.load("tvm-tmp.zip", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("tvm-tmp.zip")
@@ -783,7 +783,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("onnx-tmp")
 
-        hb_model_loaded = hummingbird.ml.ONNXContainer.load("onnx-tmp")
+        hb_model_loaded = hummingbird.ml.ONNXContainer.load("onnx-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("onnx-tmp.zip")
@@ -832,7 +832,7 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("onnx-tmp")
 
-        hb_model_loaded = hummingbird.ml.load("onnx-tmp")
+        hb_model_loaded = hummingbird.ml.load("onnx-tmp", override_flag=True)
         np.testing.assert_allclose(hb_model_loaded.predict_proba(X), hb_model.predict_proba(X), rtol=1e-06, atol=1e-06)
 
         os.remove("onnx-tmp.zip")
@@ -855,8 +855,8 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("onnx-tmp")
 
-        hummingbird.ml.load("onnx-tmp")
-        hummingbird.ml.load("onnx-tmp")
+        hummingbird.ml.load("onnx-tmp", override_flag=True)
+        hummingbird.ml.load("onnx-tmp", override_flag=True)
 
         os.remove("onnx-tmp.zip")
 
@@ -884,7 +884,7 @@ class TestBackends(unittest.TestCase):
         # Removing the configuration file with the versions does not create problems.
         os.remove(os.path.join("onnx-tmp", constants.SAVE_LOAD_MODEL_CONFIGURATION_PATH))
 
-        hummingbird.ml.load("onnx-tmp")
+        hummingbird.ml.load("onnx-tmp", override_flag=True)
         os.remove("onnx-tmp.zip")
 
     # Test for when the user forgets to add a target (ex: convert(model, output) rather than convert(model, 'torch')) due to API change

--- a/tests/test_backends.py
+++ b/tests/test_backends.py
@@ -590,8 +590,8 @@ class TestBackends(unittest.TestCase):
         self.assertIsNotNone(hb_model)
         hb_model.save("tvm-tmp.zip")
 
-        hummingbird.ml.TVMContainer.load("tvm-tmp.zip")
-        hummingbird.ml.TVMContainer.load("tvm-tmp.zip")
+        hummingbird.ml.TVMContainer.load("tvm-tmp.zip", override_flag=True)
+        hummingbird.ml.TVMContainer.load("tvm-tmp.zip", override_flag=True)
 
         os.remove("tvm-tmp.zip")
 
@@ -623,7 +623,7 @@ class TestBackends(unittest.TestCase):
         # Removing the configuration file with the versions does not create problems.
         os.remove(os.path.join("tvm-tmp", constants.SAVE_LOAD_MODEL_CONFIGURATION_PATH))
 
-        hummingbird.ml.load("tvm-tmp")
+        hummingbird.ml.load("tvm-tmp", override_flag=True)
         os.remove("tvm-tmp.zip")
 
     # Test *generic* save and load with digest


### PR DESCRIPTION
This PR makes the user explicitly set an override flag to load a stored model without providing a hash. This is to satisfy the security requirements for using pickle.