### PR TITLE
Pinning onnxruntime to < 1.18.0 to unblock pipeline

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ install_requires = [
     "protobuf>=3.20.2",
 ]
 onnx_requires = [
-    "onnxruntime>=1.0.0",
+    "onnxruntime>=1.0.0,<1.18.0",
     "onnxmltools>=1.6.0",
     "skl2onnx>=1.7.0",
 ]


### PR DESCRIPTION
See #770 and https://github.com/microsoft/onnxruntime/issues/20715  

We need to investigate what's going on with the dynamic args later, but need to unblock for now.