### PR TITLE
Deprecating Python 3.8

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-12, windows-2022]
-        python-version: ['3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11']
     env:
       TVM_VERSION_TAG: v0.16.0
       PYTORCH_VERSION: 2.2.0

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://badge.fury.io/py/hummingbird-ml.svg)](https://badge.fury.io/py/hummingbird-ml)
 [![](https://github.com/microsoft/hummingbird/workflows/Build/badge.svg?branch=main)](https://github.com/microsoft/hummingbird/actions)
-![](https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11-blue)
+![](https://img.shields.io/badge/python-3.9%20%7C%203.10%20%7C%203.11-blue)
 [![coverage](https://codecov.io/gh/microsoft/hummingbird/branch/main/graph/badge.svg)](https://codecov.io/github/microsoft/hummingbird?branch=main)
 [![Gitter](https://badges.gitter.im/hummingbird-ml/community.svg)](https://gitter.im/hummingbird-ml/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
 [![Downloads](https://pepy.tech/badge/hummingbird-ml)](https://pepy.tech/project/hummingbird-ml)
@@ -64,7 +64,7 @@ _Thank you to [Chien Vu](https://www.linkedin.com/in/vumichien/) for contributin
 
 ## Installation
 
-Hummingbird was tested on Python 3.8, 3.9, 3.10 and 3.11 on Linux, Windows and MacOS machines. (TVM only works through Python3.10.) It is recommended to use a virtual environment (See: [python3 venv doc](https://docs.python.org/3/tutorial/venv.html) or [Using Python environments in VS Code](https://code.visualstudio.com/docs/python/environments).)
+Hummingbird was tested on Python 3.9, 3.10 and 3.11 on Linux, Windows and MacOS machines. (TVM only works through Python3.10.) It is recommended to use a virtual environment (See: [python3 venv doc](https://docs.python.org/3/tutorial/venv.html) or [Using Python environments in VS Code](https://code.visualstudio.com/docs/python/environments).)
 
 Hummingbird requires PyTorch >= 1.6.0. Please go [here](https://pytorch.org/) for instructions on how to install PyTorch based on your platform and hardware.
 

--- a/tests/test_sklearn_decomposition.py
+++ b/tests/test_sklearn_decomposition.py
@@ -112,8 +112,8 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
 
     # TODO: Fails on macos-latest Python 3.8 due to a sklearn bug.
     # FastICA converter with n_components none
-    # def test_fast_ica_converter_none(self):
-    #     self._fit_model_pca(FastICA(n_components=None))
+    def test_fast_ica_converter_none(self):
+        self._fit_model_pca(FastICA(n_components=None))
 
     # FastICA converter with n_components 3
     def test_fast_ica_converter_3(self):

--- a/tests/test_sklearn_decomposition.py
+++ b/tests/test_sklearn_decomposition.py
@@ -110,7 +110,6 @@ class TestSklearnMatrixDecomposition(unittest.TestCase):
     def test_kernel_pca_converter_precomputed(self):
         self._fit_model_pca(KernelPCA(n_components=5, kernel="precomputed"), precompute=True)
 
-    # TODO: Fails on macos-latest Python 3.8 due to a sklearn bug.
     # FastICA converter with n_components none
     def test_fast_ica_converter_none(self):
         self._fit_model_pca(FastICA(n_components=None))


### PR DESCRIPTION
SKL 1.5.0 no longer supports python 3.8.  Official security support of Python 3.8 will end in October2024.