### PR TITLE
[CI] Upgrade ubuntu runner image to ubuntu-24.04

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -28,7 +28,7 @@ jobs:
     env:
       TVM_VERSION_TAG: v0.16.0
       PYTORCH_VERSION: 2.2.0
-      LLVM_VERSION: 14
+      LLVM_VERSION: 18
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-12, windows-2022]
+        os: [ubuntu-24.04, macos-12, windows-2022]
         python-version: ['3.9', '3.10', '3.11']
     env:
       TVM_VERSION_TAG: v0.16.0

--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Install LLVM if Ubuntu
       if: ${{ startsWith(matrix.os, 'ubuntu')}}
       run: |
-        sudo apt install llvm-${{ env.LLVM_VERSION }}-dev
+        sudo apt install llvm-${{ env.LLVM_VERSION }}-dev libpolly-${{ env.LLVM_VERSION }}-dev
     - name: Install LLVM if Mac
       if: ${{ startsWith(matrix.os, 'macos')}}
       run: |


### PR DESCRIPTION
Also upgrade llvm to 18 because it's the default llvm version for ubuntu 24.04.
We'll work on the macos upgrade in #785.